### PR TITLE
[FEATURE] Send data to api only after user completes checkup

### DIFF
--- a/lib/src/blocs/checkup/checkup_bloc.dart
+++ b/lib/src/blocs/checkup/checkup_bloc.dart
@@ -28,11 +28,8 @@ class CheckupBloc extends Bloc<CheckupEvent, CheckupState> {
       case StartCheckup:
         yield* _mapStartCheckupToState(event);
         break;
-      case UpdateLocalCheckup:
-        yield* _mapUpdateLocalCheckupToState(event);
-        break;
-      case UpdateRemoteCheckup:
-        yield* _mapUpdateRemoteCheckupToState(event);
+      case UpdateCheckup:
+        yield* _mapUpdateCheckupToState(event);
         break;
       case CompleteCheckup:
         yield* _mapCompleteCheckupToState(event);
@@ -51,32 +48,14 @@ class CheckupBloc extends Bloc<CheckupEvent, CheckupState> {
     yield CheckupStateInProgress(checkup: newCheckup);
   }
 
-  Stream<CheckupState> _mapUpdateLocalCheckupToState(
-      UpdateLocalCheckup event) async* {
+  Stream<CheckupState> _mapUpdateCheckupToState(UpdateCheckup event) async* {
     // Exit if checkup is not in progress
     if (state is! CheckupStateInProgress) return;
 
-    // Don't send to API yet
-    // TODO: remove this
-    print(event.updatedCheckup);
+    // Set state to updated checkup
     yield CheckupStateInProgress(
       checkup: event.updatedCheckup,
     );
-  }
-
-  Stream<CheckupState> _mapUpdateRemoteCheckupToState(
-      UpdateRemoteCheckup event) async* {
-    // Exit if checkup is not in progress
-    if (state is! CheckupStateInProgress) return;
-
-    // Retrieve current checkup
-    final CheckupStateInProgress currentState = state;
-    final Checkup currentCheckup = currentState.checkup;
-
-    // Patch checkup using API and return it (to handle server-side updates)
-    final Checkup checkup =
-        await checkupsRepository.updateCheckup(currentCheckup);
-    yield CheckupStateInProgress(checkup: checkup);
   }
 
   Stream<CheckupState> _mapCompleteCheckupToState(
@@ -91,7 +70,7 @@ class CheckupBloc extends Bloc<CheckupEvent, CheckupState> {
     final CheckupStateInProgress currentState = state;
     final Checkup currentCheckup = currentState.checkup;
 
-    // TODO: remove this
+    // TODO: remove this when API is integrated
     print(currentCheckup.toJson().toString());
 
     // Make sure checkup is up to date on server
@@ -102,7 +81,7 @@ class CheckupBloc extends Bloc<CheckupEvent, CheckupState> {
     final Assessment assessment =
         await checkupsRepository.completeCheckup(checkup.id);
 
-    // TODO: remove this
+    // TODO: remove this when API is integrated
     print(assessment.toJson().toString());
 
     // Complete checkup using API

--- a/lib/src/blocs/checkup/checkup_event.dart
+++ b/lib/src/blocs/checkup/checkup_event.dart
@@ -14,15 +14,13 @@ abstract class CheckupEvent extends Equatable {
 
 class StartCheckup extends CheckupEvent {}
 
-class UpdateLocalCheckup extends CheckupEvent {
+class UpdateCheckup extends CheckupEvent {
   final Checkup updatedCheckup;
 
-  const UpdateLocalCheckup({this.updatedCheckup});
+  const UpdateCheckup({this.updatedCheckup});
 
   @override
   List<Object> get props => [updatedCheckup];
 }
-
-class UpdateRemoteCheckup extends CheckupEvent {}
 
 class CompleteCheckup extends CheckupEvent {}

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -54,8 +54,6 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
       if (checkupState.checkup.dataContributionPreference == true) {
         await _saveCurrentLocation(checkupState);
       }
-    } else if (currentIndex > 0 && currentIndex < steps.length - 1) {
-      context.bloc<CheckupBloc>().add(UpdateRemoteCheckup());
     }
 
     setState(() {

--- a/lib/src/ui/screens/checkup/steps/intro.dart
+++ b/lib/src/ui/screens/checkup/steps/intro.dart
@@ -5,6 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:covidnearme/src/blocs/checkup/checkup.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
+import 'package:covidnearme/src/ui/utils/checkups.dart';
 import 'index.dart';
 
 class IntroStep extends StatefulWidget implements CheckupStep {
@@ -17,13 +18,20 @@ class _IntroStepState extends State<IntroStep> {
     bool value,
     CheckupStateInProgress checkupState,
   ) {
-    Checkup checkup = checkupState.checkup;
-    checkup.dataContributionPreference = value;
+    updateCheckup(
+      context: context,
+      checkupState: checkupState,
+      updateFunction: (Checkup checkup) {
+        checkup.dataContributionPreference = value;
 
-    // Make sure to clear location
-    checkup.location = null;
+        // Make sure to clear location if the user has disabled data sharing
+        if (!value) {
+          checkup.location = null;
+        }
 
-    context.bloc<CheckupBloc>().add(UpdateCheckup(updatedCheckup: checkup));
+        return checkup;
+      },
+    );
   }
 
   @override

--- a/lib/src/ui/screens/checkup/steps/intro.dart
+++ b/lib/src/ui/screens/checkup/steps/intro.dart
@@ -23,9 +23,7 @@ class _IntroStepState extends State<IntroStep> {
     // Make sure to clear location
     checkup.location = null;
 
-    context
-        .bloc<CheckupBloc>()
-        .add(UpdateLocalCheckup(updatedCheckup: checkup));
+    context.bloc<CheckupBloc>().add(UpdateCheckup(updatedCheckup: checkup));
   }
 
   @override

--- a/lib/src/ui/utils/checkups.dart
+++ b/lib/src/ui/utils/checkups.dart
@@ -12,5 +12,5 @@ void updateCheckup({
   Checkup updatedCheckup = updateFunction(checkup);
   context
       .bloc<CheckupBloc>()
-      .add(UpdateLocalCheckup(updatedCheckup: updatedCheckup));
+      .add(UpdateCheckup(updatedCheckup: updatedCheckup));
 }


### PR DESCRIPTION
Fix #16 

It is concerning from a user's perspective that data was being sent to the server after each checkup page. Now, we only send the data when the user clicks "submit" at the end of the checkup flow.

Changes:
- Removed UpdateRemoteCheckup and all references to it.
- Renamed UpdateLocalCheckup -> UpdateCheckup.
- Bonus cleanup: slight refactor to intro step to use updateCheckup helper