### PR TITLE
Show a screen asking the user for their zip code if needed

### DIFF
--- a/lib/src/ui/router.dart
+++ b/lib/src/ui/router.dart
@@ -1,20 +1,24 @@
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
+import 'package:path/path.dart';
 
 import 'screens/assessment/assessment.dart';
 import 'screens/checkup/checkup.dart';
 import 'screens/home/home.dart';
 import 'screens/tutorial/tutorial.dart';
+import 'screens/get_zip_code/get_zip_code.dart';
 
 export 'screens/assessment/assessment.dart';
 export 'screens/checkup/checkup.dart';
 export 'screens/home/home.dart';
 export 'screens/tutorial/tutorial.dart';
+export 'screens/get_zip_code/get_zip_code.dart';
 
 var appRoutes = {
   AssessmentScreen.routeName: (context) => AssessmentScreen(),
   CheckupScreen.routeName: (context) => CheckupScreen(),
   HomeScreen.routeName: (context) => HomeScreen(),
   TutorialScreen.routeName: (context) => TutorialScreen(),
+  GetZipCodeScreen.routeName: (context) => GetZipCodeScreen(),
 };
 
 String getInitialRoute(PreferencesState preferencesState) {

--- a/lib/src/ui/router.dart
+++ b/lib/src/ui/router.dart
@@ -3,15 +3,15 @@ import 'package:path/path.dart';
 
 import 'screens/assessment/assessment.dart';
 import 'screens/checkup/checkup.dart';
+import 'screens/get_zip_code/get_zip_code.dart';
 import 'screens/home/home.dart';
 import 'screens/tutorial/tutorial.dart';
-import 'screens/get_zip_code/get_zip_code.dart';
 
 export 'screens/assessment/assessment.dart';
 export 'screens/checkup/checkup.dart';
+export 'screens/get_zip_code/get_zip_code.dart';
 export 'screens/home/home.dart';
 export 'screens/tutorial/tutorial.dart';
-export 'screens/get_zip_code/get_zip_code.dart';
 
 var appRoutes = {
   AssessmentScreen.routeName: (context) => AssessmentScreen(),

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -23,18 +23,33 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
 
   void _saveCurrentLocation(CheckupStateInProgress checkupState) async {
     final Geolocator geolocator = Geolocator();
-      final GeolocationStatus permission = await geolocator.checkGeolocationPermissionStatus(locationPermission: GeolocationPermission.locationWhenInUse);
-      if(permission == GeolocationStatus.granted || permission == GeolocationStatus.restricted) {
-        final Position position = await geolocator.getCurrentPosition(
-          locationPermissionLevel: GeolocationPermission.locationWhenInUse,
-        );
-        final List<Placemark> places = await geolocator
-            .placemarkFromCoordinates(
-          position.latitude,
-          position.longitude,
-        );
-        final String postalCode = places[0].postalCode;
+    final GeolocationStatus permission =
+        await geolocator.checkGeolocationPermissionStatus(
+            locationPermission: GeolocationPermission.locationWhenInUse);
+    if (permission == GeolocationStatus.granted ||
+        permission == GeolocationStatus.restricted) {
+      final Position position = await geolocator.getCurrentPosition(
+        locationPermissionLevel: GeolocationPermission.locationWhenInUse,
+      );
+      final List<Placemark> places = await geolocator.placemarkFromCoordinates(
+        position.latitude,
+        position.longitude,
+      );
+      final String postalCode = places[0].postalCode;
 
+      updateCheckup(
+        context: context,
+        checkupState: checkupState,
+        updateFunction: (Checkup checkup) {
+          checkup.location = CheckupLocation(postalCode: postalCode);
+          return checkup;
+        },
+      );
+    } else {
+      //This returns a String, but putting an explicit type here fails.
+      final dynamic postalCode =
+          await Navigator.pushNamed(context, GetZipCodeScreen.routeName);
+      if (postalCode != null) {
         updateCheckup(
           context: context,
           checkupState: checkupState,
@@ -43,20 +58,8 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
             return checkup;
           },
         );
-      } else {
-        //This returns a String, but putting an explicit type here fails.
-        final dynamic postalCode = await Navigator.pushNamed(context, GetZipCodeScreen.routeName);
-        if(postalCode != null) {
-          updateCheckup(
-            context: context,
-            checkupState: checkupState,
-            updateFunction: (Checkup checkup) {
-              checkup.location = CheckupLocation(postalCode: postalCode);
-              return checkup;
-            },
-          );
-        }
       }
+    }
   }
 
   void _handlePageChange(

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -1,10 +1,13 @@
+import 'package:covidnearme/src/ui/assets/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:provider/provider.dart';
 
 import 'package:covidnearme/src/blocs/checkup/checkup.dart';
 import 'package:covidnearme/src/blocs/questions/questions.dart';
+import 'package:covidnearme/src/ui/router.dart';
 import 'package:covidnearme/src/ui/utils/checkups.dart';
 import 'steps/index.dart';
 import 'checkup_progress_bar.dart';
@@ -20,28 +23,40 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
 
   void _saveCurrentLocation(CheckupStateInProgress checkupState) async {
     final Geolocator geolocator = Geolocator();
+      final GeolocationStatus permission = await geolocator.checkGeolocationPermissionStatus(locationPermission: GeolocationPermission.locationWhenInUse);
+      if(permission == GeolocationStatus.granted || permission == GeolocationStatus.restricted) {
+        final Position position = await geolocator.getCurrentPosition(
+          locationPermissionLevel: GeolocationPermission.locationWhenInUse,
+        );
+        final List<Placemark> places = await geolocator
+            .placemarkFromCoordinates(
+          position.latitude,
+          position.longitude,
+        );
+        final String postalCode = places[0].postalCode;
 
-    try {
-      final Position position = await geolocator.getCurrentPosition(
-        locationPermissionLevel: GeolocationPermission.locationWhenInUse,
-      );
-      final List<Placemark> places = await geolocator.placemarkFromCoordinates(
-        position.latitude,
-        position.longitude,
-      );
-      final String postalCode = places[0].postalCode;
-
-      updateCheckup(
-        context: context,
-        checkupState: checkupState,
-        updateFunction: (Checkup checkup) {
-          checkup.location = CheckupLocation(postalCode: postalCode);
-          return checkup;
-        },
-      );
-    } catch (e) {
-      print(e);
-    }
+        updateCheckup(
+          context: context,
+          checkupState: checkupState,
+          updateFunction: (Checkup checkup) {
+            checkup.location = CheckupLocation(postalCode: postalCode);
+            return checkup;
+          },
+        );
+      } else {
+        //This returns a String, but putting an explicit type here fails.
+        final dynamic postalCode = await Navigator.pushNamed(context, GetZipCodeScreen.routeName);
+        if(postalCode != null) {
+          updateCheckup(
+            context: context,
+            checkupState: checkupState,
+            updateFunction: (Checkup checkup) {
+              checkup.location = CheckupLocation(postalCode: postalCode);
+              return checkup;
+            },
+          );
+        }
+      }
   }
 
   void _handlePageChange(

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -39,11 +39,12 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
           position.latitude,
           position.longitude,
         );
-        final String postalCode = places[0].postalCode;
+        postalCode = places[0].postalCode;
         showLocationFallback = false;
       }
     } catch (e) {
-      print(e.toString());
+      final exceptionText = e.toString();
+      print('Failed trying to access location services: $exceptionText');
     }
     if (showLocationFallback) {
       //This returns a String, but putting an explicit type here fails.

--- a/lib/src/ui/screens/get_zip_code/get_zip_code.dart
+++ b/lib/src/ui/screens/get_zip_code/get_zip_code.dart
@@ -16,22 +16,24 @@ class _GetZipCodeState extends State<GetZipCodeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text("Where Are You?")),
+      appBar: AppBar(title: Text('Where Are You?')),
       body: Column(children: <Widget>[
         Container(
           padding: EdgeInsets.all(20),
           child: Text(
-              "Please enter your zip code, or the zip code of the hospital you would go to, so that we can track the number of cases around specific hospitals."),
+              'Please enter your zip code, or the zip code of the hospital '
+              'you would go to, so that we can track the number of cases '
+              'around specific hospitals.'),
         ),
         Spacer(),
         TextField(
-          decoration: InputDecoration(labelText: "Zip Code"),
+          decoration: InputDecoration(labelText: 'Zip Code'),
           keyboardType: TextInputType.number,
           inputFormatters: <TextInputFormatter>[
             WhitelistingTextInputFormatter.digitsOnly
           ],
           onChanged: (content) {
-            if (content.contains(RegExp("^\\d{5}\$"))) {
+            if (content.contains(RegExp('^\\d{5}\$'))) {
               setState(() {
                 _postalCode = content;
               });
@@ -44,18 +46,20 @@ class _GetZipCodeState extends State<GetZipCodeScreen> {
           children: <Widget>[
             Spacer(),
             RaisedButton(
-                child: Text("Skip Location"),
-                onPressed: () {
-                  Navigator.of(context).pop(null);
-                }),
+              child: Text('Skip Location'),
+              onPressed: () {
+                Navigator.of(context).pop(null);
+              },
+            ),
             Spacer(),
             RaisedButton(
-                child: Text("Submit"),
-                onPressed: _postalCode == null
-                    ? null
-                    : () {
-                        Navigator.of(context).pop(_postalCode);
-                      }),
+              child: Text('Submit'),
+              onPressed: _postalCode == null
+                  ? null
+                  : () {
+                      Navigator.of(context).pop(_postalCode);
+                    },
+            ),
             Spacer(),
           ],
         ),

--- a/lib/src/ui/screens/get_zip_code/get_zip_code.dart
+++ b/lib/src/ui/screens/get_zip_code/get_zip_code.dart
@@ -16,11 +16,11 @@ class _GetZipCodeState extends State<GetZipCodeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Where Are You?')),
+      appBar: AppBar(title: const Text('Where Are You?')),
       body: Column(children: <Widget>[
         Container(
-          padding: EdgeInsets.all(20),
-          child: Text(
+          padding: const EdgeInsets.all(20),
+          child: const Text(
               'Please enter your zip code, or the zip code of the hospital '
               'you would go to, so that we can track the number of cases '
               'around specific hospitals.'),
@@ -46,14 +46,14 @@ class _GetZipCodeState extends State<GetZipCodeScreen> {
           children: <Widget>[
             Spacer(),
             RaisedButton(
-              child: Text('Skip Location'),
+              child: const Text('Skip Location'),
               onPressed: () {
                 Navigator.of(context).pop(null);
               },
             ),
             Spacer(),
             RaisedButton(
-              child: Text('Submit'),
+              child: const Text('Submit'),
               onPressed: _postalCode == null
                   ? null
                   : () {

--- a/lib/src/ui/screens/get_zip_code/get_zip_code.dart
+++ b/lib/src/ui/screens/get_zip_code/get_zip_code.dart
@@ -16,49 +16,51 @@ class _GetZipCodeState extends State<GetZipCodeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text("Where Are You?")
-      ),
-      body: Column(
+      appBar: AppBar(title: Text("Where Are You?")),
+      body: Column(children: <Widget>[
+        Container(
+          padding: EdgeInsets.all(20),
+          child: Text(
+              "Please enter your zip code, or the zip code of the hospital you would go to, so that we can track the number of cases around specific hospitals."),
+        ),
+        Spacer(),
+        TextField(
+          decoration: InputDecoration(labelText: "Zip Code"),
+          keyboardType: TextInputType.number,
+          inputFormatters: <TextInputFormatter>[
+            WhitelistingTextInputFormatter.digitsOnly
+          ],
+          onChanged: (content) {
+            if (content.contains(RegExp("^\\d{5}\$"))) {
+              setState(() {
+                _postalCode = content;
+              });
+            }
+          },
+          style: TextStyle(color: Colors.black),
+        ),
+        Spacer(),
+        Row(
           children: <Widget>[
-            Container(
-              padding: EdgeInsets.all(20),
-              child:Text(
-                  "Please enter your zip code, or the zip code of the hospital you would go to, so that we can track the number of cases around specific hospitals."),
-            ),
             Spacer(),
-            TextField(
-              decoration: InputDecoration(labelText: "Zip Code"),
-              keyboardType: TextInputType.number,
-              inputFormatters: <TextInputFormatter>[
-                WhitelistingTextInputFormatter.digitsOnly
-              ],
-              onChanged: (content) {
-                if(content.contains(RegExp("^\\d{5}\$"))){
-                  setState(() {
-                    _postalCode = content;
-                  });
-                }
-              },
-              style: TextStyle(color: Colors.black),
-            ),
-            Spacer(),
-            Row(
-              children: <Widget>[
-                Spacer(),
-                RaisedButton(child: Text("Skip Location"), onPressed: () {
+            RaisedButton(
+                child: Text("Skip Location"),
+                onPressed: () {
                   Navigator.of(context).pop(null);
                 }),
-                Spacer(),
-                RaisedButton(child: Text("Submit"), onPressed: _postalCode == null ? null : () {
-                  Navigator.of(context).pop(_postalCode);
-                }),
-                Spacer(),
-              ],
-            ),
             Spacer(),
-          ]),
+            RaisedButton(
+                child: Text("Submit"),
+                onPressed: _postalCode == null
+                    ? null
+                    : () {
+                        Navigator.of(context).pop(_postalCode);
+                      }),
+            Spacer(),
+          ],
+        ),
+        Spacer(),
+      ]),
     );
-
   }
 }

--- a/lib/src/ui/screens/get_zip_code/get_zip_code.dart
+++ b/lib/src/ui/screens/get_zip_code/get_zip_code.dart
@@ -1,0 +1,64 @@
+import 'package:covidnearme/src/ui/assets/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:covidnearme/src/ui/utils/checkups.dart';
+
+class GetZipCodeScreen extends StatefulWidget {
+  static const routeName = '/get_zip_code';
+
+  @override
+  _GetZipCodeState createState() => _GetZipCodeState();
+}
+
+class _GetZipCodeState extends State<GetZipCodeScreen> {
+  String _postalCode = null;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Where Are You?")
+      ),
+      body: Column(
+          children: <Widget>[
+            Container(
+              padding: EdgeInsets.all(20),
+              child:Text(
+                  "Please enter your zip code, or the zip code of the hospital you would go to, so that we can track the number of cases around specific hospitals."),
+            ),
+            Spacer(),
+            TextField(
+              decoration: InputDecoration(labelText: "Zip Code"),
+              keyboardType: TextInputType.number,
+              inputFormatters: <TextInputFormatter>[
+                WhitelistingTextInputFormatter.digitsOnly
+              ],
+              onChanged: (content) {
+                if(content.contains(RegExp("^\\d{5}\$"))){
+                  setState(() {
+                    _postalCode = content;
+                  });
+                }
+              },
+              style: TextStyle(color: Colors.black),
+            ),
+            Spacer(),
+            Row(
+              children: <Widget>[
+                Spacer(),
+                RaisedButton(child: Text("Skip Location"), onPressed: () {
+                  Navigator.of(context).pop(null);
+                }),
+                Spacer(),
+                RaisedButton(child: Text("Submit"), onPressed: _postalCode == null ? null : () {
+                  Navigator.of(context).pop(_postalCode);
+                }),
+                Spacer(),
+              ],
+            ),
+            Spacer(),
+          ]),
+    );
+
+  }
+}

--- a/lib/src/ui/screens/get_zip_code/get_zip_code.dart
+++ b/lib/src/ui/screens/get_zip_code/get_zip_code.dart
@@ -1,4 +1,5 @@
 import 'package:covidnearme/src/ui/assets/theme.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:covidnearme/src/ui/utils/checkups.dart';
@@ -11,60 +12,64 @@ class GetZipCodeScreen extends StatefulWidget {
 }
 
 class _GetZipCodeState extends State<GetZipCodeScreen> {
-  String _postalCode = null;
+  String _postalCode;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Where Are You?')),
-      body: Column(children: <Widget>[
-        Container(
-          padding: const EdgeInsets.all(20),
-          child: const Text(
-              'Please enter your zip code, or the zip code of the hospital '
-              'you would go to, so that we can track the number of cases '
-              'around specific hospitals.'),
-        ),
-        Spacer(),
-        TextField(
-          decoration: InputDecoration(labelText: 'Zip Code'),
-          keyboardType: TextInputType.number,
-          inputFormatters: <TextInputFormatter>[
-            WhitelistingTextInputFormatter.digitsOnly
-          ],
-          onChanged: (content) {
-            if (content.contains(RegExp('^\\d{5}\$'))) {
-              setState(() {
-                _postalCode = content;
-              });
-            }
-          },
-          style: TextStyle(color: Colors.black),
-        ),
-        Spacer(),
-        Row(
-          children: <Widget>[
-            Spacer(),
-            RaisedButton(
-              child: const Text('Skip Location'),
-              onPressed: () {
-                Navigator.of(context).pop(null);
+      body: Column(
+        children: <Widget>[
+          Container(
+            padding: const EdgeInsets.all(40),
+            child: const Text(
+                'Please enter your zip code, or the zip code of the hospital '
+                'you would go to, so that we can track the number of cases '
+                'around specific hospitals.'),
+          ),
+          Spacer(),
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 40),
+            child: TextField(
+              decoration: InputDecoration(labelText: 'Zip Code'),
+              keyboardType: TextInputType.number,
+              inputFormatters: <TextInputFormatter>[
+                WhitelistingTextInputFormatter.digitsOnly
+              ],
+              onChanged: (content) {
+                if (content.contains(RegExp('^\\d{5}\$'))) {
+                  setState(() {
+                    _postalCode = content;
+                  });
+                }
               },
+              style: const TextStyle(color: Colors.black),
             ),
-            Spacer(),
-            RaisedButton(
-              child: const Text('Submit'),
-              onPressed: _postalCode == null
-                  ? null
-                  : () {
-                      Navigator.of(context).pop(_postalCode);
-                    },
+          ),
+          Spacer(),
+          Container(
+            padding: const EdgeInsets.symmetric(vertical: 0, horizontal: 40),
+            child: Row(
+              children: <Widget>[
+                RaisedButton(
+                  child: const Text('Skip Location'),
+                  onPressed: () {
+                    Navigator.of(context).pop(null);
+                  },
+                ),
+                Spacer(),
+                RaisedButton(
+                  child: const Text('Submit'),
+                  onPressed: _postalCode == null
+                      ? null
+                      : () => Navigator.of(context).pop(_postalCode),
+                ),
+              ],
             ),
-            Spacer(),
-          ],
-        ),
-        Spacer(),
-      ]),
+          ),
+          Spacer(),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
This adds another screen asking the user to entry their zip code. It is launched as part of the checkup flow if location services is unavailable or the user denies permission. Implements #6 

![Screenshot_20200322-201752](https://user-images.githubusercontent.com/641166/77274414-7e105c00-6c7b-11ea-99a1-cd1217f33773.jpg)