### PR TITLE
[testing] add basic test coverage for questions bloc

### DIFF
--- a/lib/src/blocs/questions/questions_bloc.dart
+++ b/lib/src/blocs/questions/questions_bloc.dart
@@ -15,7 +15,7 @@ class QuestionsBloc extends Bloc<QuestionsEvent, QuestionsState> {
   QuestionsBloc({@required this.questionsRepository});
 
   @override
-  QuestionsState get initialState => QuestionsStateNotLoaded();
+  QuestionsState get initialState => const QuestionsStateNotLoaded();
 
   @override
   Stream<QuestionsState> mapEventToState(QuestionsEvent event) async* {
@@ -27,12 +27,12 @@ class QuestionsBloc extends Bloc<QuestionsEvent, QuestionsState> {
   }
 
   Stream<QuestionsState> _mapLoadQuestionsToState(LoadQuestions event) async* {
-    yield QuestionsStateLoading();
+    yield const QuestionsStateLoading();
 
     try {
       final questions = await questionsRepository.listQuestions();
       yield QuestionsStateLoaded(questions);
-    } catch (exception) {
+    } on Exception catch (exception) {
       developer.log(
         'Could not load questions list',
         error: exception,

--- a/lib/src/blocs/questions/questions_state.dart
+++ b/lib/src/blocs/questions/questions_state.dart
@@ -12,9 +12,13 @@ abstract class QuestionsState extends Equatable {
   bool get stringify => true;
 }
 
-class QuestionsStateNotLoaded extends QuestionsState {}
+class QuestionsStateNotLoaded extends QuestionsState {
+  const QuestionsStateNotLoaded();
+}
 
-class QuestionsStateLoading extends QuestionsState {}
+class QuestionsStateLoading extends QuestionsState {
+  const QuestionsStateLoading();
+}
 
 class QuestionsStateLoaded extends QuestionsState {
   final List<Question> questions;

--- a/test/blocs/questions_test.dart
+++ b/test/blocs/questions_test.dart
@@ -1,0 +1,77 @@
+import 'package:covidnearme/src/blocs/questions/questions.dart';
+import 'package:covidnearme/src/data/repositories/questions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('LoadQuestions has no props by default', () {
+    expect(LoadQuestions().props, isEmpty);
+  });
+
+  test('LoadQuestions stringifies with no props', () {
+    expect(LoadQuestions().toString(), 'LoadQuestions()');
+  });
+
+  test(
+      'QuestionsBloc does not yield additional states if it receives actions '
+      'other than LoadQuestions', () async {
+    final bloc = QuestionsBloc(questionsRepository: QuestionsRepository());
+    bloc.add(NotQuestion());
+    bloc.close();
+
+    await expectLater(
+      bloc,
+      emitsInOrder(
+        [
+          QuestionsStateNotLoaded(),
+          // No further events are emitted.
+        ],
+      ),
+    );
+  });
+
+  test(
+      'QuestionsBloc returns the question list after loading when it receives '
+      'a LoadQuestions event', () async {
+    final bloc = QuestionsBloc(questionsRepository: QuestionsRepository());
+    bloc.add(LoadQuestions());
+    bloc.close();
+
+    await expectLater(
+      bloc,
+      emitsInOrder(
+        [
+          const QuestionsStateNotLoaded(),
+          const QuestionsStateLoading(),
+          isA<QuestionsStateLoaded>(),
+        ],
+      ),
+    );
+  });
+
+  test('QuestionsBloc catches Exceptions thrown when loading the question list',
+      () async {
+    final bloc = QuestionsBloc(questionsRepository: FakeQuestionsRepository());
+    bloc.add(LoadQuestions());
+    bloc.close();
+
+    await expectLater(
+      bloc,
+      emitsInOrder(
+        [
+          const QuestionsStateNotLoaded(),
+          const QuestionsStateLoading(),
+          isA<QuestionsStateLoadingFailed>(),
+        ],
+      ),
+    );
+  });
+}
+
+class NotQuestion extends QuestionsEvent {}
+
+class FakeQuestionsRepository implements QuestionsRepository {
+  @override
+  Future<List<Question>> listQuestions() {
+    throw Exception('Failed to load');
+  }
+}

--- a/test/blocs/questions_test.dart
+++ b/test/blocs/questions_test.dart
@@ -11,9 +11,7 @@ void main() {
     expect(LoadQuestions().toString(), 'LoadQuestions()');
   });
 
-  test(
-      'QuestionsBloc does not yield additional states if it receives actions '
-      'other than LoadQuestions', () async {
+  test('QuestionsBloc only responds to LoadQuestions events', () async {
     final bloc = QuestionsBloc(questionsRepository: QuestionsRepository());
     bloc.add(NotQuestion());
     bloc.close();

--- a/test/blocs/questions_test.dart
+++ b/test/blocs/questions_test.dart
@@ -21,7 +21,7 @@ void main() {
       emitsInOrder(
         [
           QuestionsStateNotLoaded(),
-          // No further events are emitted.
+          emitsDone,
         ],
       ),
     );
@@ -41,6 +41,7 @@ void main() {
           const QuestionsStateNotLoaded(),
           const QuestionsStateLoading(),
           isA<QuestionsStateLoaded>(),
+          emitsDone,
         ],
       ),
     );
@@ -59,6 +60,7 @@ void main() {
           const QuestionsStateNotLoaded(),
           const QuestionsStateLoading(),
           isA<QuestionsStateLoadingFailed>(),
+          emitsDone,
         ],
       ),
     );

--- a/test/blocs/questions_test.dart
+++ b/test/blocs/questions_test.dart
@@ -72,6 +72,6 @@ class NotQuestion extends QuestionsEvent {}
 class FakeQuestionsRepository implements QuestionsRepository {
   @override
   Future<List<Question>> listQuestions() {
-    throw Exception('Failed to load');
+    throw Exception('Failed to load.');
   }
 }


### PR DESCRIPTION
- Adds basic test coverage for the QuestionsBloc, covering some of the bloc specific logic.
- Adds `const` constructors to `QuestionsStateNotLoaded` and `QuestionsStateLoading`. Since these classes have no members they can be made trivially const.
- Updates the bloc catch clause to be `on Exception`. Without this, the catch might catch errors such as `NoSuchMethorError` or `TypeError` (See also https://dart.dev/guides/language/effective-dart/usage#avoid-catches-without-on-clauses)

https://github.com/coronavirus-diary/coronavirus-diary/issues/12