### PR TITLE
Disallow horizontal scrolling in health checkup

### DIFF
--- a/lib/src/ui/screens/checkup/checkup.dart
+++ b/lib/src/ui/screens/checkup/checkup.dart
@@ -38,7 +38,7 @@ class _CheckupScreenState extends State<CheckupScreen> {
     CheckupState checkupState,
   ) {
     if (checkupState is CheckupStateNotCreated) {
-      context.bloc<CheckupBloc>().add(StartCheckup());
+      context.bloc<CheckupBloc>().add(const StartCheckup());
     }
     return LoadingIndicator('Loading your health checkup');
   }

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -88,11 +88,12 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
                 ),
                 AnimatedSwitcher(
                   duration: const Duration(milliseconds: 200),
-                  child: currentStep != null && currentIndex > 0 ?
-                    CheckupProgressBar(
-                      currentIndex: currentIndex,
-                      stepsLength: steps.length,
-                    ): null,
+                  child: currentStep != null && currentIndex > 0
+                      ? CheckupProgressBar(
+                          currentIndex: currentIndex,
+                          stepsLength: steps.length,
+                        )
+                      : null,
                 ),
               ],
             );

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -49,17 +49,17 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
     CheckupStateInProgress checkupState,
     QuestionsState questionsState,
   ) async {
-    // Origin-specific actions
-    if (currentIndex == 0) {
-      if (checkupState.checkup.dataContributionPreference == true) {
-        await _saveCurrentLocation(checkupState);
-      }
-    }
-
+    final int oldIndex = currentIndex;
     setState(() {
       currentIndex = index;
       currentStep = steps[index];
     });
+    // Origin-specific actions
+    if (oldIndex == 0) {
+      if (checkupState.checkup.dataContributionPreference == true) {
+        await _saveCurrentLocation(checkupState);
+      }
+    }
   }
 
   @override
@@ -71,10 +71,10 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
         return BlocBuilder<QuestionsBloc, QuestionsState>(
           builder: (context, state) {
             final QuestionsState questionsState = state;
-
             return Stack(
               children: <Widget>[
                 PageView.builder(
+                  physics: NeverScrollableScrollPhysics(),
                   controller: Provider.of<PageController>(context),
                   onPageChanged: (int index) => _handlePageChange(
                     index,
@@ -86,11 +86,14 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
                     return steps[index];
                   },
                 ),
-                if (currentStep != null && currentIndex > 0)
-                  CheckupProgressBar(
-                    currentIndex: currentIndex,
-                    stepsLength: steps.length,
-                  ),
+                AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 200),
+                  child: currentStep != null && currentIndex > 0 ?
+                    CheckupProgressBar(
+                      currentIndex: currentIndex,
+                      stepsLength: steps.length,
+                    ): null,
+                ),
               ],
             );
           },

--- a/lib/src/ui/screens/checkup/checkup_progress_bar.dart
+++ b/lib/src/ui/screens/checkup/checkup_progress_bar.dart
@@ -58,12 +58,14 @@ class CheckupProgressBar extends StatelessWidget {
               ],
             ),
           ),
-          SizedBox(
-            height: 20,
-            child: LinearProgressIndicator(
-              value: percentComplete,
-              backgroundColor: Colors.white.withOpacity(0.2),
-              valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
+          ExcludeSemantics(
+            child: SizedBox(
+              height: 20,
+              child: LinearProgressIndicator(
+                value: percentComplete,
+                backgroundColor: Colors.white.withOpacity(0.2),
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
+              ),
             ),
           ),
         ],

--- a/test/ui/screens/checkup_test.dart
+++ b/test/ui/screens/checkup_test.dart
@@ -1,0 +1,81 @@
+import 'package:covidnearme/src/blocs/checkup/checkup.dart';
+import 'package:covidnearme/src/blocs/preferences/preferences.dart';
+import 'package:covidnearme/src/blocs/questions/questions_bloc.dart';
+import 'package:covidnearme/src/data/repositories/checkups.dart';
+import 'package:covidnearme/src/data/repositories/questions.dart';
+import 'package:covidnearme/src/ui/screens/checkup/checkup.dart';
+import 'package:file/memory.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+void main() {
+  setUp(() async {
+    // Use a hermetic file system that is cleaned up between tests.
+    final fs = MemoryFileSystem.test();
+
+    BlocSupervisor.delegate = await HydratedBlocDelegate.build(
+      storageDirectory: fs.systemTempDirectory.createTempSync(),
+    );
+  });
+
+  testWidgets('CheckupScreen transitions from loading to health checkup', (tester) async {
+    await tester.pumpWidget(setUpCheckupScreen());
+
+    // Loading screen
+    expect(find.text('Loading your health checkup'), findsOneWidget);
+
+    // Finish loading transition.
+    await tester.pumpAndSettle();
+
+    expect(find.text("It's time for your checkup."), findsOneWidget);
+  });
+
+  testWidgets('Cannot advance to the next screen by scrolling', (tester) async {
+    const String page1 = "It's time for your checkup.";
+    const String page2 = "Step 1 of 2";
+
+    await tester.pumpWidget(setUpCheckupScreen());
+    await tester.pumpAndSettle();
+
+    expect(find.text(page1), findsOneWidget);
+    await tester.drag(find.text(page1), Offset(-400, 0));
+    await tester.pumpAndSettle();
+    expect(find.text(page1), findsOneWidget);
+    expect(find.text(page2), findsNothing);
+
+    await tester.tap(find.text('Start checkup'));
+    await tester.pumpAndSettle();
+    expect(find.text(page1), findsNothing);
+    expect(find.text(page2), findsOneWidget);
+  });
+}
+
+Widget setUpCheckupScreen({
+  QuestionsBloc questions,
+  CheckupBloc checkup,
+  PreferencesBloc preferences,
+}) {
+  questions ??= QuestionsBloc(questionsRepository: QuestionsRepository());
+  checkup ??= CheckupBloc(
+    preferencesState: PreferencesState(preferences: Preferences()),
+    checkupsRepository: CheckupsRepository(),
+  );
+  preferences ??= PreferencesBloc();
+  return MaterialApp(
+    home: Scaffold(
+      body: BlocProvider(
+        create: (BuildContext context) => questions,
+        child: BlocProvider(
+          create: (BuildContext context) => checkup,
+          child: BlocProvider(
+            create: (BuildContext context) => preferences,
+            child: CheckupScreen(),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/test/ui/screens/checkup_test.dart
+++ b/test/ui/screens/checkup_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     expect(find.text("It's time for your checkup."), findsOneWidget);
   });
-  
+
   testWidgets('Cannot advance to the next screen by scrolling', (tester) async {
     const String page1 = "It's time for your checkup.";
     const String page2 = "Step 1 of 2";


### PR DESCRIPTION
Changes in this PR:
* The health checkup no longer scrolls in horizontal direction (users will have to use the continue button)
* The progress bar always appears even if location setup fails.
* The progress bar animated in.
* Small a11y fix to progress bar.

Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/37
Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/30