### PR TITLE
Make continue/submit buttons not be pinned.

### DIFF
--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -91,7 +91,8 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
                   child: currentStep != null && currentIndex > 0
                       ? CheckupProgressBar(
                           currentIndex: currentIndex,
-                          stepsLength: steps.length,
+                          // Subtract one because the intro isn't really a step.
+                          stepsLength: steps.length - 1,
                         )
                       : null,
                 ),

--- a/lib/src/ui/screens/checkup/checkup_progress_bar.dart
+++ b/lib/src/ui/screens/checkup/checkup_progress_bar.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:provider/provider.dart';
 
-import 'package:covidnearme/src/blocs/checkup/checkup.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 
 class CheckupProgressBar extends StatelessWidget {
@@ -17,17 +14,6 @@ class CheckupProgressBar extends StatelessWidget {
   })  : isLastPage = currentIndex == stepsLength - 1,
         percentComplete = (currentIndex) / (stepsLength - 1);
 
-  _handleNextButton(BuildContext context) {
-    if (isLastPage) {
-      context.bloc<CheckupBloc>().add(CompleteCheckup());
-    } else {
-      Provider.of<PageController>(context, listen: false).nextPage(
-        duration: Duration(milliseconds: 400),
-        curve: Curves.easeInOut,
-      );
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     // Remember to update this if steps are added that do not count towards the total
@@ -35,12 +21,22 @@ class CheckupProgressBar extends StatelessWidget {
     String percentCompleteText = localizations
         .checkupProgressBarPercentCompleteText(currentIndex, stepsLength);
     return Align(
-      alignment: Alignment.bottomCenter,
+      alignment: Alignment.topCenter,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.end,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
+          ExcludeSemantics(
+            child: SizedBox(
+              height: 20,
+              child: LinearProgressIndicator(
+                value: percentComplete,
+                backgroundColor: Colors.white.withOpacity(0.2),
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
+              ),
+            ),
+          ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
             child: Row(
@@ -50,26 +46,10 @@ class CheckupProgressBar extends StatelessWidget {
                   percentCompleteText,
                   style: TextStyle(
                     color: Colors.white,
-                    fontSize: 18,
+                    fontSize: 14,
                   ),
                 ),
-                RaisedButton(
-                  onPressed: () => _handleNextButton(context),
-                  child: Text(isLastPage
-                      ? localizations.checkupProgressBarSubmit
-                      : localizations.checkupProgressBarContinue),
-                ),
               ],
-            ),
-          ),
-          ExcludeSemantics(
-            child: SizedBox(
-              height: 20,
-              child: LinearProgressIndicator(
-                value: percentComplete,
-                backgroundColor: Colors.white.withOpacity(0.2),
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.green),
-              ),
             ),
           ),
         ],

--- a/lib/src/ui/screens/checkup/steps/index.dart
+++ b/lib/src/ui/screens/checkup/steps/index.dart
@@ -4,7 +4,11 @@ import 'intro.dart';
 import 'subjective.dart';
 import 'temperature.dart';
 
-abstract class CheckupStep extends Widget {}
+abstract class CheckupStep extends Widget {
+  CheckupStep();
+
+  bool get isLastStep;
+}
 
 final List<CheckupStep> steps = [
   IntroStep(),

--- a/lib/src/ui/screens/checkup/steps/intro.dart
+++ b/lib/src/ui/screens/checkup/steps/intro.dart
@@ -10,6 +10,8 @@ import 'package:covidnearme/src/ui/utils/checkups.dart';
 import 'index.dart';
 
 class IntroStep extends StatefulWidget implements CheckupStep {
+  bool get isLastStep => false;
+
   @override
   _IntroStepState createState() => _IntroStepState();
 }

--- a/lib/src/ui/screens/checkup/steps/subjective.dart
+++ b/lib/src/ui/screens/checkup/steps/subjective.dart
@@ -9,6 +9,8 @@ import 'package:covidnearme/src/ui/utils/checkups.dart';
 import 'index.dart';
 
 class SubjectiveStep extends StatefulWidget implements CheckupStep {
+  bool get isLastStep => false;
+
   @override
   _SubjectiveStepState createState() => _SubjectiveStepState();
 }
@@ -64,10 +66,11 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
           builder: (context, state) {
             final CheckupStateInProgress checkupState = state;
             return QuestionView(
-              padding: EdgeInsets.only(bottom: 80),
+              padding: EdgeInsets.only(top: 20, bottom: 80),
               questions: questionState.questions,
               onChange: (Question question, dynamic value) =>
                   _updateCheckup(question, value, checkupState),
+              isLastStep: widget.isLastStep,
             );
           },
         );

--- a/lib/src/ui/screens/checkup/steps/temperature.dart
+++ b/lib/src/ui/screens/checkup/steps/temperature.dart
@@ -1,3 +1,4 @@
+import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,6 +12,8 @@ import 'package:covidnearme/src/ui/utils/checkups.dart';
 import 'index.dart';
 
 class TemperatureStep extends StatefulWidget implements CheckupStep {
+  bool get isLastStep => true;
+
   @override
   _TemperatureStepState createState() => _TemperatureStepState();
 }
@@ -242,12 +245,13 @@ class _TemperatureStepState extends State<TemperatureStep> {
                   ],
                 ),
                 Container(
-                  margin: EdgeInsets.only(top: 50),
+                  margin: EdgeInsets.only(top: 25, bottom: 40),
                   child: RaisedButton(
                     onPressed: _showInstructions,
                     child: Text(localizations.temperatureStepHelp),
                   ),
                 ),
+                StepFinishedButton(isLastStep: true),
               ],
             ),
           ),

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
 import 'package:covidnearme/src/data/models/questions.dart';
+
 import 'question_item.dart';
+import 'step_finished_button.dart';
 import '../scrollable_body.dart';
 
 class QuestionView extends StatefulWidget {
@@ -9,12 +11,14 @@ class QuestionView extends StatefulWidget {
   final Color color;
   final EdgeInsetsGeometry padding;
   final Function(Question question, dynamic value) onChange;
+  final bool isLastStep;
 
   const QuestionView({
     @required this.questions,
     this.color,
     this.padding,
     this.onChange,
+    this.isLastStep,
   });
 
   @override
@@ -39,7 +43,10 @@ class _QuestionViewState extends State<QuestionView> {
       child: ScrollableBody(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.center,
-          children: _getQuestions(),
+          children: [
+            ..._getQuestions(),
+            StepFinishedButton(),
+          ],
         ),
       ),
     );

--- a/lib/src/ui/widgets/questions/step_finished_button.dart
+++ b/lib/src/ui/widgets/questions/step_finished_button.dart
@@ -17,7 +17,7 @@ class StepFinishedButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
     return Container(
-      padding: EdgeInsets.only(left: 20, right: 20),
+      padding: EdgeInsets.symmetric(horizontal: 20),
       width: 400,
       child: RaisedButton(
         onPressed: () {

--- a/lib/src/ui/widgets/questions/step_finished_button.dart
+++ b/lib/src/ui/widgets/questions/step_finished_button.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:covidnearme/src/blocs/checkup/checkup.dart';
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+
+class StepFinishedButton extends StatelessWidget {
+  const StepFinishedButton({
+    Key key,
+    this.isLastStep = false,
+  }) : super(key: key);
+
+  final bool isLastStep;
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+    return Container(
+      padding: EdgeInsets.only(left: 20, right: 20),
+      width: 400,
+      child: RaisedButton(
+        onPressed: () {
+          if (isLastStep) {
+            context.bloc<CheckupBloc>().add(CompleteCheckup());
+          } else {
+            Provider.of<PageController>(context, listen: false).nextPage(
+              duration: Duration(milliseconds: 400),
+              curve: Curves.easeInOut,
+            );
+          }
+        },
+        child: Text(isLastStep
+            ? localizations.checkupProgressBarSubmit
+            : localizations.checkupProgressBarContinue),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,13 +249,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_xlider:
-    dependency: "direct main"
-    description:
-      name: flutter_xlider
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.2.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -554,7 +547,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "1.4.2"
   pubspec_parse:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -249,6 +249,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_xlider:
+    dependency: "direct main"
+    description:
+      name: flutter_xlider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -547,7 +554,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.4"
   pubspec_parse:
     dependency: transitive
     description:


### PR DESCRIPTION
## Description

This fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/24, by moving the continue/submit button to the bottom of the scrollable, and also moves the progress bar to the top of the question display, both to improve the UI so that it doesn't overlap, and to keep people from continuing/submitting before they have seen all of the questions.