### PR TITLE
Make tutorial pages non-scrollable

### DIFF
--- a/lib/src/ui/screens/tutorial/steps/consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/consent.dart
@@ -18,11 +18,13 @@ class ConsentStep extends StatelessWidget {
     );
     context.bloc<PreferencesBloc>().add(UpdatePreferences(newPreferences));
 
-    // Navigate to next page
-    Provider.of<PageController>(context, listen: false).nextPage(
-      duration: Duration(milliseconds: 400),
-      curve: Curves.easeInOut,
-    );
+    if (response) {
+      // Advance to the next page if consent is given.
+      Provider.of<PageController>(context, listen: false).nextPage(
+        duration: Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      );
+    }
   }
 
   @override

--- a/lib/src/ui/screens/tutorial/tutorial.dart
+++ b/lib/src/ui/screens/tutorial/tutorial.dart
@@ -35,6 +35,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
           body: ChangeNotifierProvider<PageController>.value(
             value: _pageController,
             child: PageView(
+              physics: NeverScrollableScrollPhysics(),
               controller: _pageController,
               children: <Widget>[
                 IntroStep(),


### PR DESCRIPTION
https://github.com/coronavirus-diary/coronavirus-diary/issues/37

Also stop letting pressing "No!" attempt to advance the tutorial flow and triggering an overflow glow since the next page isn't available.