### PR TITLE
[testing] create a bloc delegate that forwards to FlutterError reporter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,13 @@
+import 'package:covidnearme/src/blocs/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 import 'src/app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  BlocSupervisor.delegate = await HydratedBlocDelegate.build();
+  BlocSupervisor.delegate = await AppHydratedBlocDelegate.build();
   runApp(Phoenix(
     child: App(),
   ));

--- a/lib/src/blocs/utils.dart
+++ b/lib/src/blocs/utils.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+/// An implementation of [HydratedBlocDelegate] that forwards exceptions to
+/// [FlutterError.onError];
+class AppHydratedBlocDelegate extends HydratedBlocDelegate {
+  AppHydratedBlocDelegate(HydratedStorage storage) : super(storage);
+
+  static Future<HydratedBlocDelegate> build({
+    Directory storageDirectory,
+  }) async {
+    return AppHydratedBlocDelegate(
+      await HydratedBlocStorage.getInstance(storageDirectory: storageDirectory),
+    );
+  }
+
+  @override
+  void onError(Bloc bloc, Object error, StackTrace stacktrace) {
+    FlutterError.onError(FlutterErrorDetails(
+      exception: error,
+      stack: stacktrace,
+      context: DiagnosticsNode.message('In Bloc $bloc'),
+    ));
+    super.onError(bloc, error, stacktrace);
+  }
+}

--- a/test/blocs/utils_test.dart
+++ b/test/blocs/utils_test.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:covidnearme/src/blocs/utils.dart';
+import 'package:file/memory.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('AppHydratedBlocDelegate forwards errors to FlutterError.onError',
+      () async {
+    BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
+        storageDirectory: MemoryFileSystem.test().currentDirectory);
+
+    final onErrorCompleter = Completer<FlutterErrorDetails>();
+    FlutterError.onError = onErrorCompleter.complete;
+    BadBloc().add(null);
+
+    expect(
+        await onErrorCompleter.future,
+        isA<FlutterErrorDetails>()
+          ..having((d) => d.exception, 'exception', contains('Hello there')));
+  });
+}
+
+class BadBloc extends Bloc<void, void> {
+  @override
+  void get initialState => null;
+
+  @override
+  Stream<void> mapEventToState(void event) async* {
+    throw Exception('Hello There');
+  }
+}


### PR DESCRIPTION
Adds AppHydratedBlocDelegate which is meant to be used in place of  HydratedBlocDelegate. This implements the `onError` functionality to forward to flutter's generic mechanism for reporting errors during development. This prevents them from going unnoticed in tests, where it can appear that blocs get "stuck" if they throw uncaught exceptions.

For example, if an exception was thrown in the `CheckupBlock` during development, you might see:

```
🔥  To hot reload changes while running, press "r". To hot restart (and rebuild state), press "R".
An Observatory debugger and profiler on iPhone 11 Pro Max is available at: http://127.0.0.1:64190/9aCbjIkJiz0=/
For a more detailed help message, press "h". To detach, press "d"; to quit, press "q".
flutter: ══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════
flutter: The following _Exception was thrown In Bloc Instance of 'CheckupBloc':
flutter: Exception: asd
flutter:
flutter: When the exception was thrown, this was the stack:
flutter: #0      CheckupBloc._mapStartCheckupToState (package:covidnearme/src/blocs/checkup/checkup_bloc.dart:44:5)
flutter: <asynchronous suspension>
flutter: #1      CheckupBloc.mapEventToState (package:covidnearme/src/blocs/checkup/checkup_bloc.dart:29:16)
flutter: <asynchronous suspension>
flutter: #2      Bloc._bindStateSubject.<anonymous closure> (package:bloc/src/bloc.dart:155:14)
flutter: (elided 18 frames from package dart:async)
flutter: ════════════════════════════════════════════════════════════════════════════════════════════════════
```


Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/88