### PR TITLE
Added temporary copy of gen_l10n

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -2,8 +2,32 @@
 
 This is a temporary copy of the Flutter beta version of the gen_l10n tool.
 
-When messages are added/removed/changed in the Coronavirus Diary app's lib/src/app_en.arb file, the gen_l10n.dart tool must be run to update the generated AppLocalization class:
+Internationalization support landed in https://github.com/coronavirus-diary/coronavirus-diary/pull/95. This change enables the app to be localized for different languages.  The app now looks up messages (user visible text strings) via the AppLocalizations class, see lib/src/l10n/app_localizations.dart. This class was generated from lib/src/l10n/app_en.arb - the app's message "template" file" - using the beta version of the Flutter gen_l10n tool. The English localizations, lib/src/l10n/app_localizations_en.dart, were generated this way as well. Each message is defined by two entries in the template file. For example these entries define the message called temperatureStepWait30Minutes:
 
-```dart
+```
+"temperatureStepWait30Minutes": "Wait 30 minutes after eating, drinking, or exercising",
+"@temperatureStepWait30Minutes": {
+  "description": "User advice"
+},
+```
+
+The name of the message corresponds to Widget that uses it, `TemperatureStep`, along with a suffix that's supposed to help someone reading the code to understand what the message refers to. The second "@" entry will be visible to translators. It's required.
+
+Many developers are still adding and modifying messages and will need a way to update the AppLocalization class themselves. I've added a copy of the beta version of the gen_l10n tool to this repo:
+
+https://github.com/coronavirus-diary/coronavirus-diary/pull/102
+
+Once this PR has landed:
+
+- To change a message that's currently retrieved by the AppLocalizations class, change the corresponding entry in lib/src/l10n/app_en.arb and then run the local copy of gen_l10n:
+
+```
 ${FLUTTER_HOME}/bin/cache/dart-sdk/bin/dart tools/gen_l10n.dart --arb-dir lib/src/l10n
 ```
+
+As you know, you'll also have to run `flutter format .` because.
+
+
+- To add a message, add a pair of message entries to lib/src/l10n/app_en.arb and then run the gen_l10n tool. Be careful to follow JSON conventions for commas or gen_l10n will fail with `fatal: Unexpected character`.
+
+- To remove message, remove its entries from lib/src/l10n/app_en.arb and then run the gen_l10n tool.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,9 @@
+# Temporary copy of dev/tools/gen_l10n et al.
+
+This is a temporary copy of the Flutter beta version of the gen_l10n tool.
+
+When messages are added/removed/changed in the Coronavirus Diary app's lib/src/app_en.arb file, the gen_l10n.dart tool must be run to update the generated AppLocalization class:
+
+```dart
+${FLUTTER_HOME}/bin/cache/dart-sdk/bin/dart tools/gen_l10n.dart --arb-dir lib/src/l10n
+```

--- a/tools/gen_l10n.dart
+++ b/tools/gen_l10n.dart
@@ -13,6 +13,8 @@ import 'gen_l10n_lib.dart';
 import 'gen_l10n_types.dart';
 import 'localizations_utils.dart';
 
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 Future<void> main(List<String> arguments) async {
   final argslib.ArgParser parser = argslib.ArgParser();
   parser.addFlag(

--- a/tools/gen_l10n.dart
+++ b/tools/gen_l10n.dart
@@ -1,0 +1,114 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:args/args.dart' as argslib;
+import 'package:file/local.dart' as local;
+import 'package:path/path.dart' as path;
+
+import 'gen_l10n_lib.dart';
+import 'gen_l10n_types.dart';
+import 'localizations_utils.dart';
+
+Future<void> main(List<String> arguments) async {
+  final argslib.ArgParser parser = argslib.ArgParser();
+  parser.addFlag(
+    'help',
+    defaultsTo: false,
+    negatable: false,
+    help: 'Print this help message.',
+  );
+  parser.addOption(
+    'arb-dir',
+    defaultsTo: path.join('lib', 'l10n'),
+    help: 'The directory where all localization files should reside. For '
+        'example, the template and translated arb files should be located here. '
+        'Also, the generated output messages Dart files for each locale and the '
+        'generated localizations classes will be created here.',
+  );
+  parser.addOption(
+    'template-arb-file',
+    defaultsTo: 'app_en.arb',
+    help: 'The template arb file that will be used as the basis for '
+        'generating the Dart localization and messages files.',
+  );
+  parser.addOption(
+    'output-localization-file',
+    defaultsTo: 'app_localizations.dart',
+    help: 'The filename for the output localization and localizations '
+        'delegate classes.',
+  );
+  parser.addOption(
+    'output-class',
+    defaultsTo: 'AppLocalizations',
+    help: 'The Dart class name to use for the output localization and '
+        'localizations delegate classes.',
+  );
+  parser.addOption(
+    'preferred-supported-locales',
+    help: 'The list of preferred supported locales for the application. '
+        'By default, the tool will generate the supported locales list in '
+        'alphabetical order. Use this flag if you would like to default to '
+        'a different locale. \n\n'
+        "For example, pass in ['en_US'] if you would like your app to "
+        'default to American English if a device supports it.',
+  );
+  parser.addOption('header',
+      help: 'The header to prepend to the generated Dart localizations '
+          'files. This option takes in a string. \n\n'
+          'For example, pass in "/// All localized files." if you would '
+          'like this string prepended to the generated Dart file. \n\n'
+          'Alternatively, see the `header-file` option to pass in a text '
+          'file for longer headers.');
+  parser.addOption('header-file',
+      help: 'The header to prepend to the generated Dart localizations '
+          'files. The value of this option is the name of the file that '
+          'contains the header text. \n\n'
+          'Alternatively, see the `header` option to pass in a string '
+          'for a simpler header.');
+
+  final argslib.ArgResults results = parser.parse(arguments);
+  if (results['help'] == true) {
+    print(parser.usage);
+    exit(0);
+  }
+
+  await precacheLanguageAndRegionTags();
+
+  final String arbPathString = results['arb-dir'] as String;
+  final String outputFileString = results['output-localization-file'] as String;
+  final String templateArbFileName = results['template-arb-file'] as String;
+  final String classNameString = results['output-class'] as String;
+  final String preferredSupportedLocaleString =
+      results['preferred-supported-locales'] as String;
+  final String headerString = results['header'] as String;
+  final String headerFile = results['header-file'] as String;
+
+  const local.LocalFileSystem fs = local.LocalFileSystem();
+  final LocalizationsGenerator localizationsGenerator =
+      LocalizationsGenerator(fs);
+
+  try {
+    localizationsGenerator
+      ..initialize(
+        l10nDirectoryPath: arbPathString,
+        templateArbFileName: templateArbFileName,
+        outputFileString: outputFileString,
+        classNameString: classNameString,
+        preferredSupportedLocaleString: preferredSupportedLocaleString,
+        headerString: headerString,
+        headerFile: headerFile,
+      )
+      ..loadResources()
+      ..writeOutputFile();
+  } on FileSystemException catch (e) {
+    exitWithError(e.message);
+  } on FormatException catch (e) {
+    exitWithError(e.message);
+  } on L10nException catch (e) {
+    exitWithError(e.message);
+  }
+}

--- a/tools/gen_l10n_lib.dart
+++ b/tools/gen_l10n_lib.dart
@@ -13,6 +13,8 @@ import 'gen_l10n_templates.dart';
 import 'gen_l10n_types.dart';
 import 'localizations_utils.dart';
 
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 List<String> generateMethodParameters(Message message) {
   assert(message.placeholders.isNotEmpty);
   final Placeholder countPlaceholder =

--- a/tools/gen_l10n_lib.dart
+++ b/tools/gen_l10n_lib.dart
@@ -1,0 +1,663 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file/file.dart' as file;
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+
+import 'gen_l10n_templates.dart';
+import 'gen_l10n_types.dart';
+import 'localizations_utils.dart';
+
+List<String> generateMethodParameters(Message message) {
+  assert(message.placeholders.isNotEmpty);
+  final Placeholder countPlaceholder =
+      message.isPlural ? message.getCountPlaceholder() : null;
+  return message.placeholders.map((Placeholder placeholder) {
+    final String type =
+        placeholder == countPlaceholder ? 'int' : placeholder.type;
+    return '$type ${placeholder.name}';
+  }).toList();
+}
+
+String generateDateFormattingLogic(Message message) {
+  if (message.placeholders.isEmpty || !message.placeholdersRequireFormatting)
+    return '@(none)';
+
+  final Iterable<String> formatStatements = message.placeholders
+      .where((Placeholder placeholder) => placeholder.isDate)
+      .map((Placeholder placeholder) {
+    if (placeholder.format == null) {
+      throw L10nException(
+          'The placeholder, ${placeholder.name}, has its "type" resource attribute set to '
+          'the "${placeholder.type}" type. To properly resolve for the right '
+          '${placeholder.type} format, the "format" attribute needs to be set '
+          'to determine which DateFormat to use. \n'
+          'Check the intl library\'s DateFormat class constructors for allowed '
+          'date formats.');
+    }
+    if (!placeholder.hasValidDateFormat) {
+      throw L10nException('Date format "${placeholder.format}" for placeholder '
+          '${placeholder.name} does not have a corresponding DateFormat '
+          'constructor\n. Check the intl library\'s DateFormat class '
+          'constructors for allowed date formats.');
+    }
+    return dateFormatTemplate
+        .replaceAll('@(placeholder)', placeholder.name)
+        .replaceAll('@(format)', placeholder.format);
+  });
+
+  return formatStatements.isEmpty ? '@(none)' : formatStatements.join('');
+}
+
+String generateNumberFormattingLogic(Message message) {
+  if (message.placeholders.isEmpty || !message.placeholdersRequireFormatting) {
+    return '@(none)';
+  }
+
+  final Iterable<String> formatStatements = message.placeholders
+      .where((Placeholder placeholder) => placeholder.isNumber)
+      .map((Placeholder placeholder) {
+    if (!placeholder.hasValidNumberFormat) {
+      throw L10nException(
+          'Number format ${placeholder.format} for the ${placeholder.name} '
+          'placeholder does not have a corresponding NumberFormat constructor.\n'
+          'Check the intl library\'s NumberFormat class constructors for allowed '
+          'number formats.');
+    }
+    final Iterable<String> parameters =
+        placeholder.optionalParameters.map<String>(
+      (OptionalParameter parameter) {
+        return '${parameter.name}: ${parameter.value}';
+      },
+    );
+    return numberFormatTemplate
+        .replaceAll('@(placeholder)', placeholder.name)
+        .replaceAll('@(format)', placeholder.format)
+        .replaceAll('@(parameters)', parameters.join(',    \n'));
+  });
+
+  return formatStatements.isEmpty ? '@(none)' : formatStatements.join('');
+}
+
+String generatePluralMethod(Message message) {
+  if (message.placeholders.isEmpty) {
+    throw L10nException(
+        'Unable to find placeholders for the plural message: ${message.resourceId}.\n'
+        'Check to see if the plural message is in the proper ICU syntax format '
+        'and ensure that placeholders are properly specified.');
+  }
+
+  // To make it easier to parse the plurals message, temporarily replace each
+  // "{placeholder}" parameter with "#placeholder#".
+  String easyMessage = message.value;
+  for (final Placeholder placeholder in message.placeholders)
+    easyMessage = easyMessage.replaceAll(
+        '{${placeholder.name}}', '#${placeholder.name}#');
+
+  final Placeholder countPlaceholder = message.getCountPlaceholder();
+  if (countPlaceholder == null) {
+    throw L10nException(
+        'Unable to find the count placeholder for the plural message: ${message.resourceId}.\n'
+        'Check to see if the plural message is in the proper ICU syntax format '
+        'and ensure that placeholders are properly specified.');
+  }
+
+  const Map<String, String> pluralIds = <String, String>{
+    '=0': 'zero',
+    '=1': 'one',
+    '=2': 'two',
+    'few': 'few',
+    'many': 'many',
+    'other': 'other'
+  };
+
+  final List<String> pluralLogicArgs = <String>[];
+  for (final String pluralKey in pluralIds.keys) {
+    final RegExp expRE = RegExp('($pluralKey)\\s*{([^}]+)}');
+    final RegExpMatch match = expRE.firstMatch(easyMessage);
+    if (match != null && match.groupCount == 2) {
+      String argValue = match.group(2);
+      for (final Placeholder placeholder in message.placeholders) {
+        if (placeholder != countPlaceholder && placeholder.requiresFormatting) {
+          argValue = argValue.replaceAll(
+              '#${placeholder.name}#', '\${${placeholder.name}String}');
+        } else {
+          argValue = argValue.replaceAll(
+              '#${placeholder.name}#', '\${${placeholder.name}}');
+        }
+      }
+      pluralLogicArgs.add("      ${pluralIds[pluralKey]}: '$argValue'");
+    }
+  }
+
+  final List<String> parameters =
+      message.placeholders.map((Placeholder placeholder) {
+    final String placeholderType =
+        placeholder == countPlaceholder ? 'int' : placeholder.type;
+    return '$placeholderType ${placeholder.name}';
+  }).toList();
+
+  final String comment = message.description ??
+      'No description provided in @${message.resourceId}';
+
+  return pluralMethodTemplate
+      .replaceAll('@(comment)', comment)
+      .replaceAll('@(name)', message.resourceId)
+      .replaceAll('@(parameters)', parameters.join(', '))
+      .replaceAll('@(dateFormatting)', generateDateFormattingLogic(message))
+      .replaceAll('@(numberFormatting)', generateNumberFormattingLogic(message))
+      .replaceAll('@(count)', countPlaceholder.name)
+      .replaceAll('@(pluralLogicArgs)', pluralLogicArgs.join(',\n'))
+      .replaceAll('@(none)\n', '');
+}
+
+String generateMethod(Message message, AppResourceBundle bundle) {
+  String generateMessage() {
+    String messageValue = bundle.translationFor(message);
+    for (final Placeholder placeholder in message.placeholders) {
+      if (placeholder.requiresFormatting) {
+        messageValue = messageValue.replaceAll(
+            '{${placeholder.name}}', '\${${placeholder.name}String}');
+      } else {
+        messageValue = messageValue.replaceAll(
+            '{${placeholder.name}}', '\${${placeholder.name}}');
+      }
+    }
+
+    return generateString(messageValue, escapeDollar: false);
+  }
+
+  if (message.isPlural) {
+    return generatePluralMethod(message);
+  }
+
+  if (message.placeholdersRequireFormatting) {
+    return formatMethodTemplate
+        .replaceAll('@(name)', message.resourceId)
+        .replaceAll(
+            '@(parameters)', generateMethodParameters(message).join(', '))
+        .replaceAll('@(dateFormatting)', generateDateFormattingLogic(message))
+        .replaceAll(
+            '@(numberFormatting)', generateNumberFormattingLogic(message))
+        .replaceAll('@(message)', generateMessage())
+        .replaceAll('@(none)\n', '');
+  }
+
+  if (message.placeholders.isNotEmpty) {
+    return methodTemplate
+        .replaceAll('@(name)', message.resourceId)
+        .replaceAll(
+            '@(parameters)', generateMethodParameters(message).join(', '))
+        .replaceAll('@(message)', generateMessage());
+  }
+
+  return getterTemplate
+      .replaceAll('@(name)', message.resourceId)
+      .replaceAll('@(message)', generateMessage());
+}
+
+String generateBaseClassFile(
+  String className,
+  String fileName,
+  String header,
+  AppResourceBundle bundle,
+  Iterable<Message> messages,
+) {
+  final LocaleInfo locale = bundle.locale;
+  final Iterable<String> methods = messages
+      .where((Message message) => bundle.translationFor(message) != null)
+      .map((Message message) => generateMethod(message, bundle));
+
+  return classFileTemplate
+      .replaceAll('@(header)', header)
+      .replaceAll('@(language)', describeLocale(locale.toString()))
+      .replaceAll('@(baseClass)', className)
+      .replaceAll('@(fileName)', fileName)
+      .replaceAll('@(class)', '$className${locale.camelCase()}')
+      .replaceAll('@(localeName)', locale.toString())
+      .replaceAll('@(methods)', methods.join('\n\n'));
+}
+
+String generateSubclass({
+  String className,
+  AppResourceBundle bundle,
+  Iterable<Message> messages,
+}) {
+  final LocaleInfo locale = bundle.locale;
+  final String baseClassName =
+      '$className${LocaleInfo.fromString(locale.languageCode).camelCase()}';
+
+  final Iterable<String> methods = messages
+      .where((Message message) => bundle.translationFor(message) != null)
+      .map((Message message) => generateMethod(message, bundle));
+
+  return subclassTemplate
+      .replaceAll('@(language)', describeLocale(locale.toString()))
+      .replaceAll('@(baseLanguageClassName)', baseClassName)
+      .replaceAll('@(class)', '$className${locale.camelCase()}')
+      .replaceAll('@(localeName)', locale.toString())
+      .replaceAll('@(methods)', methods.join('\n\n'));
+}
+
+String generateBaseClassMethod(Message message) {
+  final String comment = message.description ??
+      'No description provided in @${message.resourceId}';
+  if (message.placeholders.isNotEmpty) {
+    return baseClassMethodTemplate
+        .replaceAll('@(comment)', comment)
+        .replaceAll('@(name)', message.resourceId)
+        .replaceAll(
+            '@(parameters)', generateMethodParameters(message).join(', '));
+  }
+  return baseClassGetterTemplate
+      .replaceAll('@(comment)', comment)
+      .replaceAll('@(name)', message.resourceId);
+}
+
+String generateLookupBody(
+    AppResourceBundleCollection allBundles, String className) {
+  final Iterable<String> switchClauses =
+      allBundles.languages.map((String language) {
+    final Iterable<LocaleInfo> locales =
+        allBundles.localesForLanguage(language);
+    if (locales.length == 1) {
+      return switchClauseTemplate
+          .replaceAll('@(case)', language)
+          .replaceAll('@(class)', '$className${locales.first.camelCase()}');
+    }
+
+    final Iterable<LocaleInfo> localesWithCountryCodes =
+        locales.where((LocaleInfo locale) => locale.countryCode != null);
+    return countryCodeSwitchTemplate
+        .replaceAll('@(languageCode)', language)
+        .replaceAll('@(class)',
+            '$className${LocaleInfo.fromString(language).camelCase()}')
+        .replaceAll(
+            '@(switchClauses)',
+            localesWithCountryCodes.map((LocaleInfo locale) {
+              return switchClauseTemplate
+                  .replaceAll('@(case)', locale.countryCode)
+                  .replaceAll('@(class)', '$className${locale.camelCase()}');
+            }).join('\n        '));
+  });
+  return switchClauses.join('\n    ');
+}
+
+class LocalizationsGenerator {
+  /// Creates an instance of the localizations generator class.
+  ///
+  /// It takes in a [FileSystem] representation that the class will act upon.
+  LocalizationsGenerator(this._fs);
+
+  final file.FileSystem _fs;
+  Iterable<Message> _allMessages;
+  AppResourceBundleCollection _allBundles;
+
+  /// The reference to the project's l10n directory.
+  ///
+  /// It is assumed that all input files (e.g. [templateArbFile], arb files
+  /// for translated messages) and output files (e.g. The localizations
+  /// [outputFile], `messages_<locale>.dart` and `messages_all.dart`)
+  /// will reside here.
+  ///
+  /// This directory is specified with the [initialize] method.
+  Directory l10nDirectory;
+
+  /// The input arb file which defines all of the messages that will be
+  /// exported by the generated class that's written to [outputFile].
+  ///
+  /// This file is specified with the [initialize] method.
+  File templateArbFile;
+
+  /// The file to write the generated localizations and localizations delegate
+  /// classes to.
+  ///
+  /// This file is specified with the [initialize] method.
+  File outputFile;
+
+  /// The class name to be used for the localizations class in [outputFile].
+  ///
+  /// For example, if 'AppLocalizations' is passed in, a class named
+  /// AppLocalizations will be used for localized message lookups.
+  ///
+  /// The class name is specified with the [initialize] method.
+  String get className => _className;
+  String _className;
+
+  /// The list of preferred supported locales.
+  ///
+  /// By default, the list of supported locales in the localizations class
+  /// will be sorted in alphabetical order. However, this option
+  /// allows for a set of preferred locales to appear at the top of the
+  /// list.
+  ///
+  /// The order of locales in this list will also be the order of locale
+  /// priority. For example, if a device supports 'en' and 'es' and
+  /// ['es', 'en'] is passed in, the 'es' locale will take priority over 'en'.
+  ///
+  /// The list of preferred locales is specified with the [initialize] method.
+  List<LocaleInfo> get preferredSupportedLocales => _preferredSupportedLocales;
+  List<LocaleInfo> _preferredSupportedLocales;
+
+  /// The list of all arb path strings in [l10nDirectory].
+  List<String> get arbPathStrings {
+    return _allBundles.bundles
+        .map((AppResourceBundle bundle) => bundle.file.path)
+        .toList();
+  }
+
+  /// The supported language codes as found in the arb files located in
+  /// [l10nDirectory].
+  final Set<String> supportedLanguageCodes = <String>{};
+
+  /// The supported locales as found in the arb files located in
+  /// [l10nDirectory].
+  final Set<LocaleInfo> supportedLocales = <LocaleInfo>{};
+
+  /// The header to be prepended to the generated Dart localization file.
+  String header = '';
+
+  /// Initializes [l10nDirectory], [templateArbFile], [outputFile] and [className].
+  ///
+  /// Throws an [L10nException] when a provided configuration is not allowed
+  /// by [LocalizationsGenerator].
+  ///
+  /// Throws a [FileSystemException] when a file operation necessary for setting
+  /// up the [LocalizationsGenerator] cannot be completed.
+  void initialize({
+    String l10nDirectoryPath,
+    String templateArbFileName,
+    String outputFileString,
+    String classNameString,
+    String preferredSupportedLocaleString,
+    String headerString,
+    String headerFile,
+  }) {
+    setL10nDirectory(l10nDirectoryPath);
+    setTemplateArbFile(templateArbFileName);
+    setOutputFile(outputFileString);
+    setPreferredSupportedLocales(preferredSupportedLocaleString);
+    _setHeader(headerString, headerFile);
+    className = classNameString;
+  }
+
+  static bool _isNotReadable(FileStat fileStat) {
+    final String rawStatString = fileStat.modeString();
+    // Removes potential prepended permission bits, such as '(suid)' and '(guid)'.
+    final String statString = rawStatString.substring(rawStatString.length - 9);
+    return !(statString[0] == 'r' ||
+        statString[3] == 'r' ||
+        statString[6] == 'r');
+  }
+
+  static bool _isNotWritable(FileStat fileStat) {
+    final String rawStatString = fileStat.modeString();
+    // Removes potential prepended permission bits, such as '(suid)' and '(guid)'.
+    final String statString = rawStatString.substring(rawStatString.length - 9);
+    return !(statString[1] == 'w' ||
+        statString[4] == 'w' ||
+        statString[7] == 'w');
+  }
+
+  /// Sets the reference [Directory] for [l10nDirectory].
+  @visibleForTesting
+  void setL10nDirectory(String arbPathString) {
+    if (arbPathString == null)
+      throw L10nException('arbPathString argument cannot be null');
+    l10nDirectory = _fs.directory(arbPathString);
+    if (!l10nDirectory.existsSync())
+      throw FileSystemException(
+          "The 'arb-dir' directory, $l10nDirectory, does not exist.\n"
+          'Make sure that the correct path was provided.');
+
+    final FileStat fileStat = l10nDirectory.statSync();
+    if (_isNotReadable(fileStat) || _isNotWritable(fileStat))
+      throw FileSystemException(
+          "The 'arb-dir' directory, $l10nDirectory, doesn't allow reading and writing.\n"
+          'Please ensure that the user has read and write permissions.');
+  }
+
+  /// Sets the reference [File] for [templateArbFile].
+  @visibleForTesting
+  void setTemplateArbFile(String templateArbFileName) {
+    if (templateArbFileName == null)
+      throw L10nException('templateArbFileName argument cannot be null');
+    if (l10nDirectory == null)
+      throw L10nException(
+          'l10nDirectory cannot be null when setting template arb file');
+
+    templateArbFile =
+        _fs.file(path.join(l10nDirectory.path, templateArbFileName));
+    final String templateArbFileStatModeString =
+        templateArbFile.statSync().modeString();
+    if (templateArbFileStatModeString[0] == '-' &&
+        templateArbFileStatModeString[3] == '-')
+      throw FileSystemException(
+          "The 'template-arb-file', $templateArbFile, is not readable.\n"
+          'Please ensure that the user has read permissions.');
+  }
+
+  /// Sets the reference [File] for the localizations delegate [outputFile].
+  @visibleForTesting
+  void setOutputFile(String outputFileString) {
+    if (outputFileString == null)
+      throw L10nException('outputFileString argument cannot be null');
+    outputFile = _fs.file(path.join(l10nDirectory.path, outputFileString));
+  }
+
+  static bool _isValidClassName(String className) {
+    // Public Dart class name cannot begin with an underscore
+    if (className[0] == '_') return false;
+    // Dart class name cannot contain non-alphanumeric symbols
+    if (className.contains(RegExp(r'[^a-zA-Z_\d]'))) return false;
+    // Dart class name must start with upper case character
+    if (className[0].contains(RegExp(r'[a-z]'))) return false;
+    // Dart class name cannot start with a number
+    if (className[0].contains(RegExp(r'\d'))) return false;
+    return true;
+  }
+
+  /// Sets the [className] for the localizations and localizations delegate
+  /// classes.
+  @visibleForTesting
+  set className(String classNameString) {
+    if (classNameString == null || classNameString.isEmpty)
+      throw L10nException('classNameString argument cannot be null or empty');
+    if (!_isValidClassName(classNameString))
+      throw L10nException(
+          "The 'output-class', $classNameString, is not a valid public Dart class name.\n");
+    _className = classNameString;
+  }
+
+  /// Sets [preferredSupportedLocales] so that this particular list of locales
+  /// will take priority over the other locales.
+  @visibleForTesting
+  void setPreferredSupportedLocales(String inputLocales) {
+    if (inputLocales == null || inputLocales.trim().isEmpty) {
+      _preferredSupportedLocales = const <LocaleInfo>[];
+    } else {
+      final List<dynamic> preferredLocalesStringList =
+          json.decode(inputLocales) as List<dynamic>;
+      _preferredSupportedLocales =
+          preferredLocalesStringList.map((dynamic localeString) {
+        if (localeString.runtimeType != String) {
+          throw L10nException('Incorrect runtime type for $localeString');
+        }
+        return LocaleInfo.fromString(localeString.toString());
+      }).toList();
+    }
+  }
+
+  void _setHeader(String headerString, String headerFile) {
+    if (headerString != null && headerFile != null) {
+      throw L10nException(
+          'Cannot accept both header and header file arguments. \n'
+          'Please make sure to define only one or the other. ');
+    }
+
+    if (headerString != null) {
+      header = headerString;
+    } else if (headerFile != null) {
+      try {
+        header = _fs
+            .file(path.join(l10nDirectory.path, headerFile))
+            .readAsStringSync();
+      } on FileSystemException catch (error) {
+        throw L10nException('Failed to read header file: "$headerFile". \n'
+            'FileSystemException: ${error.message}');
+      }
+    }
+  }
+
+  static bool _isValidGetterAndMethodName(String name) {
+    // Public Dart method name must not start with an underscore
+    if (name[0] == '_') return false;
+    // Dart getter and method name cannot contain non-alphanumeric symbols
+    if (name.contains(RegExp(r'[^a-zA-Z_\d]'))) return false;
+    // Dart method name must start with lower case character
+    if (name[0].contains(RegExp(r'[A-Z]'))) return false;
+    // Dart class name cannot start with a number
+    if (name[0].contains(RegExp(r'\d'))) return false;
+    return true;
+  }
+
+  // Load _allMessages from templateArbFile and _allBundles from all of the ARB
+  // files in l10nDirectory. Also initialized: supportedLocales.
+  void loadResources() {
+    final AppResourceBundle templateBundle = AppResourceBundle(templateArbFile);
+    _allMessages = templateBundle.resourceIds
+        .map((String id) => Message(templateBundle.resources, id));
+    for (final String resourceId in templateBundle.resourceIds)
+      if (!_isValidGetterAndMethodName(resourceId)) {
+        throw L10nException(
+            'Invalid ARB resource name "$resourceId" in $templateArbFile.\n'
+            'Resources names must be valid Dart method names: they have to be '
+            'camel case, cannot start with a number or underscore, and cannot '
+            'contain non-alphanumeric characters.');
+      }
+
+    _allBundles = AppResourceBundleCollection(l10nDirectory);
+
+    final List<LocaleInfo> allLocales =
+        List<LocaleInfo>.from(_allBundles.locales);
+    for (final LocaleInfo preferredLocale in preferredSupportedLocales) {
+      final int index = allLocales.indexOf(preferredLocale);
+      if (index == -1) {
+        throw L10nException(
+            "The preferred supported locale, '$preferredLocale', cannot be "
+            'added. Please make sure that there is a corresponding ARB file '
+            'with translations for the locale, or remove the locale from the '
+            'preferred supported locale list.');
+      }
+      allLocales.removeAt(index);
+      allLocales.insertAll(0, preferredSupportedLocales);
+    }
+    supportedLocales.addAll(allLocales);
+  }
+
+  // Generate the AppLocalizations class, its LocalizationsDelegate subclass,
+  // and all AppLocalizations subclasses for every locale.
+  String generateCode() {
+    bool isBaseClassLocale(LocaleInfo locale, String language) {
+      return locale.languageCode == language &&
+          locale.countryCode == null &&
+          locale.scriptCode == null;
+    }
+
+    List<LocaleInfo> getLocalesForLanguage(String language) {
+      return _allBundles.bundles
+          // Return locales for the language specified, except for the base locale itself
+          .where((AppResourceBundle bundle) {
+            final LocaleInfo locale = bundle.locale;
+            return !isBaseClassLocale(locale, language) &&
+                locale.languageCode == language;
+          })
+          .map((AppResourceBundle bundle) => bundle.locale)
+          .toList();
+    }
+
+    final String directory = path.basename(l10nDirectory.path);
+    final String outputFileName = path.basename(outputFile.path);
+
+    final Iterable<String> supportedLocalesCode =
+        supportedLocales.map((LocaleInfo locale) {
+      final String country = locale.countryCode;
+      final String countryArg = country == null ? '' : "', '$country";
+      return 'Locale(\'${locale.languageCode}$countryArg\')';
+    });
+
+    final Set<String> supportedLanguageCodes = Set<String>.from(_allBundles
+        .locales
+        .map<String>((LocaleInfo locale) => '\'${locale.languageCode}\''));
+
+    final List<LocaleInfo> allLocales = _allBundles.locales.toList()..sort();
+    final String fileName = outputFileName.split('.')[0];
+    for (final LocaleInfo locale in allLocales) {
+      if (isBaseClassLocale(locale, locale.languageCode)) {
+        final File localeMessageFile = _fs.file(
+          path.join(l10nDirectory.path, '${fileName}_$locale.dart'),
+        );
+
+        // Generate the template for the base class file. Further string
+        // interpolation will be done to determine if there are
+        // subclasses that extend the base class.
+        final String languageBaseClassFile = generateBaseClassFile(
+          className,
+          outputFileName,
+          header,
+          _allBundles.bundleFor(locale),
+          _allMessages,
+        );
+
+        // Every locale for the language except the base class.
+        final List<LocaleInfo> localesForLanguage =
+            getLocalesForLanguage(locale.languageCode);
+
+        // Generate every subclass that is needed for the particular language
+        final Iterable<String> subclasses =
+            localesForLanguage.map<String>((LocaleInfo locale) {
+          return generateSubclass(
+            className: className,
+            bundle: _allBundles.bundleFor(locale),
+            messages: _allMessages,
+          );
+        });
+
+        localeMessageFile.writeAsStringSync(
+          languageBaseClassFile.replaceAll('@(subclasses)', subclasses.join()),
+        );
+      }
+    }
+
+    final Iterable<String> localeImports = supportedLocales
+        .where((LocaleInfo locale) =>
+            isBaseClassLocale(locale, locale.languageCode))
+        .map((LocaleInfo locale) {
+      return "import '${fileName}_${locale.toString()}.dart';";
+    });
+
+    final String lookupBody = generateLookupBody(_allBundles, className);
+
+    return fileTemplate
+        .replaceAll('@(header)', header)
+        .replaceAll('@(class)', className)
+        .replaceAll(
+            '@(methods)', _allMessages.map(generateBaseClassMethod).join('\n'))
+        .replaceAll('@(importFile)', '$directory/$outputFileName')
+        .replaceAll('@(supportedLocales)', supportedLocalesCode.join(',\n    '))
+        .replaceAll(
+            '@(supportedLanguageCodes)', supportedLanguageCodes.join(', '))
+        .replaceAll('@(messageClassImports)', localeImports.join('\n'))
+        .replaceAll('@(lookupName)', '_lookup$className')
+        .replaceAll('@(lookupBody)', lookupBody);
+  }
+
+  void writeOutputFile() {
+    outputFile.writeAsStringSync(generateCode());
+  }
+}

--- a/tools/gen_l10n_templates.dart
+++ b/tools/gen_l10n_templates.dart
@@ -1,0 +1,217 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const String fileTemplate = '''
+@(header)
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+
+@(messageClassImports)
+
+// ignore_for_file: unnecessary_brace_in_string_interps
+
+/// Callers can lookup localized strings with an instance of @(class) returned
+/// by `@(class).of(context)`.
+///
+/// Applications need to include `@(class).delegate()` in their app\'s
+/// localizationDelegates list, and the locales they support in the app\'s
+/// supportedLocales list. For example:
+///
+/// ```
+/// import '@(importFile)';
+///
+/// return MaterialApp(
+///   localizationsDelegates: @(class).localizationsDelegates,
+///   supportedLocales: @(class).supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: 0.16.0
+///   intl_translation: 0.17.7
+///
+///   # rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the @(class).supportedLocales
+/// property.
+abstract class @(class) {
+  @(class)(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  // ignore: unused_field
+  final String localeName;
+
+  static @(class) of(BuildContext context) {
+    return Localizations.of<@(class)>(context, @(class));
+  }
+
+  static const LocalizationsDelegate<@(class)> delegate = _@(class)Delegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    @(supportedLocales)
+  ];
+
+@(methods)}
+
+class _@(class)Delegate extends LocalizationsDelegate<@(class)> {
+  const _@(class)Delegate();
+
+  @override
+  Future<@(class)> load(Locale locale) {
+    return SynchronousFuture<@(class)>(@(lookupName)(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) => <String>[@(supportedLanguageCodes)].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_@(class)Delegate old) => false;
+}
+
+@(class) @(lookupName)(Locale locale) {
+  switch(locale.languageCode) {
+    @(lookupBody)
+  }
+  assert(false, '@(class).delegate failed to load unsupported locale "\$locale"');
+  return null;
+}
+''';
+
+const String numberFormatTemplate = '''
+    final intl.NumberFormat @(placeholder)NumberFormat = intl.NumberFormat.@(format)(
+      locale: localeName,
+      @(parameters)
+    );
+    final String @(placeholder)String = @(placeholder)NumberFormat.format(@(placeholder));
+''';
+
+const String dateFormatTemplate = '''
+    final intl.DateFormat @(placeholder)DateFormat = intl.DateFormat.@(format)(localeName);
+    final String @(placeholder)String = @(placeholder)DateFormat.format(@(placeholder));
+''';
+
+const String getterTemplate = '''
+  @override
+  String get @(name) => @(message);''';
+
+const String methodTemplate = '''
+  @override
+  String @(name)(@(parameters)) {
+    return @(message);
+  }''';
+
+const String formatMethodTemplate = '''
+  @override
+  String @(name)(@(parameters)) {
+@(dateFormatting)
+@(numberFormatting)
+    return @(message);
+  }''';
+
+const String pluralMethodTemplate = '''
+  @override
+  String @(name)(@(parameters)) {
+@(dateFormatting)
+@(numberFormatting)
+    return intl.Intl.pluralLogic(
+      @(count),
+      locale: localeName,
+@(pluralLogicArgs),
+    );
+  }''';
+
+const String classFileTemplate = '''
+@(header)
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import '@(fileName)';
+
+// ignore_for_file: unnecessary_brace_in_string_interps
+
+/// The translations for @(language) (`@(localeName)`).
+class @(class) extends @(baseClass) {
+  @(class)([String locale = '@(localeName)']) : super(locale);
+
+@(methods)
+}
+@(subclasses)''';
+
+const String subclassTemplate = '''
+
+/// The translations for @(language) (`@(localeName)`).
+class @(class) extends @(baseLanguageClassName) {
+  @(class)(): super('@(localeName)');
+
+@(methods)
+}
+''';
+
+const String baseClassGetterTemplate = '''
+  // @(comment)
+  String get @(name);
+''';
+
+const String baseClassMethodTemplate = '''
+  // @(comment)
+  String @(name)(@(parameters));
+''';
+
+const String switchClauseTemplate = '''case '@(case)': return @(class)();''';
+
+const String countryCodeSwitchTemplate = '''case '@(languageCode)': {
+      switch (locale.countryCode) {
+        @(switchClauses)
+      }
+      return @(class)();
+    }''';

--- a/tools/gen_l10n_types.dart
+++ b/tools/gen_l10n_types.dart
@@ -1,0 +1,472 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'localizations_utils.dart';
+
+// The set of date formats that can be automatically localized.
+//
+// The localizations generation tool makes use of the intl library's
+// DateFormat class to properly format dates based on the locale, the
+// desired format, as well as the passed in [DateTime]. For example, using
+// DateFormat.yMMMMd("en_US").format(DateTime.utc(1996, 7, 10)) results
+// in the string "July 10, 1996".
+//
+// Since the tool generates code that uses DateFormat's constructor, it is
+// necessary to verify that the constructor exists, or the
+// tool will generate code that may cause a compile-time error.
+//
+// See also:
+//
+// * <https://pub.dev/packages/intl>
+// * <https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html>
+// * <https://api.dartlang.org/stable/2.7.0/dart-core/DateTime-class.html>
+const Set<String> _validDateFormats = <String>{
+  'd',
+  'E',
+  'EEEE',
+  'LLL',
+  'LLLL',
+  'M',
+  'Md',
+  'MEd',
+  'MMM',
+  'MMMd',
+  'MMMEd',
+  'MMMM',
+  'MMMMd',
+  'MMMMEEEEd',
+  'QQQ',
+  'QQQQ',
+  'y',
+  'yM',
+  'yMd',
+  'yMEd',
+  'yMMM',
+  'yMMMd',
+  'yMMMEd',
+  'yMMMM',
+  'yMMMMd',
+  'yMMMMEEEEd',
+  'yQQQ',
+  'yQQQQ',
+  'H',
+  'Hm',
+  'Hms',
+  'j',
+  'jm',
+  'jms',
+  'jmv',
+  'jmz',
+  'jv',
+  'jz',
+  'm',
+  'ms',
+  's',
+};
+
+// The set of number formats that can be automatically localized.
+//
+// The localizations generation tool makes use of the intl library's
+// NumberFormat class to properly format numbers based on the locale, the
+// desired format, as well as the passed in number. For example, using
+// DateFormat.compactLong("en_US").format(1200000) results
+// in the string "1.2 million".
+//
+// Since the tool generates code that uses NumberFormat's constructor, it is
+// necessary to verify that the constructor exists, or the
+// tool will generate code that may cause a compile-time error.
+//
+// See also:
+//
+// * <https://pub.dev/packages/intl>
+// * <https://pub.dev/documentation/intl/latest/intl/NumberFormat-class.html>
+const Set<String> _validNumberFormats = <String>{
+  'compact',
+  'compactCurrency',
+  'compactSimpleCurrency',
+  'compactLong',
+  'currency',
+  'decimalPattern',
+  'decimalPercentPattern',
+  'percentPattern',
+  'scientificPattern',
+  'simpleCurrency',
+};
+
+// The names of the NumberFormat factory constructors which have named
+// parameters rather than positional parameters.
+//
+// This helps the tool correctly generate number formmatting code correctly.
+//
+// Example of code that uses named parameters:
+// final NumberFormat format = NumberFormat.compact(
+//   locale: localeName,
+// );
+//
+// Example of code that uses positional parameters:
+// final NumberFormat format = NumberFormat.scientificPattern(localeName);
+const Set<String> _numberFormatsWithNamedParameters = <String>{
+  'compact',
+  'compactCurrency',
+  'compactSimpleCurrency',
+  'compactLong',
+  'currency',
+  'decimalPercentPattern',
+  'simpleCurrency',
+};
+
+class L10nException implements Exception {
+  L10nException(this.message);
+
+  final String message;
+}
+
+// One optional named parameter to be used by a NumberFormat.
+//
+// Some of the NumberFormat factory constructors have optional named parameters.
+// For example NumberFormat.compactCurrency has a decimalDigits parameter that
+// specifies the number of decimal places to use when formatting.
+//
+// Optional parameters for NumberFormat placeholders are specified as a
+// JSON map value for optionalParameters in a resource's "@" ARB file entry:
+//
+// "@myResourceId": {
+//   "placeholders": {
+//     "myNumberPlaceholder": {
+//       "type": "double",
+//       "format": "compactCurrency",
+//       "optionalParameters": {
+//         "decimalDigits": 2
+//       }
+//     }
+//   }
+// }
+class OptionalParameter {
+  const OptionalParameter(this.name, this.value)
+      : assert(name != null),
+        assert(value != null);
+
+  final String name;
+  final Object value;
+}
+
+// One message parameter: one placeholder from an @foo entry in the template ARB file.
+//
+// Placeholders are specified as a JSON map with one entry for each placeholder.
+// One placeholder must be specified for each message "{parameter}".
+// Each placeholder entry is also a JSON map. If the map is empty, the placeholder
+// is assumed to be an Object value whose toString() value will be displayed.
+// For example:
+//
+// "greeting": "{hello} {world}",
+// "@greeting": {
+//   "description": "A message with a two parameters",
+//   "placeholders": {
+//     "hello": {},
+//     "world": {}
+//   }
+// }
+//
+// Each placeholder can optionally specify a valid Dart type. If the type
+// is NumberFormat or DateFormat then a format which matches one of the
+// type's factory constructors can also be specified. In this example the
+// date placeholder is to be formated with DateFormat.yMMMMd:
+//
+// "helloWorldOn": "Hello World on {date}",
+// "@helloWorldOn": {
+//   "description": "A message with a date parameter",
+//   "placeholders": {
+//     "date": {
+//       "type": "DateTime",
+//       "format": "yMMMMd"
+//     }
+//   }
+// }
+//
+class Placeholder {
+  Placeholder(this.resourceId, this.name, Map<String, dynamic> attributes)
+      : assert(resourceId != null),
+        assert(name != null),
+        example = _stringAttribute(resourceId, name, attributes, 'example'),
+        type =
+            _stringAttribute(resourceId, name, attributes, 'type') ?? 'Object',
+        format = _stringAttribute(resourceId, name, attributes, 'format'),
+        optionalParameters = _optionalParameters(resourceId, name, attributes);
+
+  final String resourceId;
+  final String name;
+  final String example;
+  final String type;
+  final String format;
+  final List<OptionalParameter> optionalParameters;
+
+  bool get requiresFormatting =>
+      <String>['DateTime', 'double', 'int', 'num'].contains(type);
+  bool get isNumber => <String>['double', 'int', 'num'].contains(type);
+  bool get hasValidNumberFormat => _validNumberFormats.contains(format);
+  bool get hasNumberFormatWithParameters =>
+      _numberFormatsWithNamedParameters.contains(format);
+  bool get isDate => 'DateTime' == type;
+  bool get hasValidDateFormat => _validDateFormats.contains(format);
+
+  static String _stringAttribute(
+    String resourceId,
+    String name,
+    Map<String, dynamic> attributes,
+    String attributeName,
+  ) {
+    final dynamic value = attributes[attributeName];
+    if (value == null) return null;
+    if (value is! String || (value as String).isEmpty) {
+      throw L10nException(
+        'The "$attributeName" value of the "$name" placeholder in message $resourceId '
+        'must be a non-empty string.',
+      );
+    }
+    return value as String;
+  }
+
+  static List<OptionalParameter> _optionalParameters(
+      String resourceId, String name, Map<String, dynamic> attributes) {
+    final dynamic value = attributes['optionalParameters'];
+    if (value == null) return <OptionalParameter>[];
+    if (value is! Map<String, Object>) {
+      throw L10nException(
+          'The "optionalParameters" value of the "$name" placeholder in message '
+          '$resourceId is not a properly formatted Map. Ensure that it is a map '
+          'with keys that are strings.');
+    }
+    final Map<String, dynamic> optionalParameterMap =
+        value as Map<String, dynamic>;
+    return optionalParameterMap.keys
+        .map<OptionalParameter>((String parameterName) {
+      return OptionalParameter(
+          parameterName, optionalParameterMap[parameterName]);
+    }).toList();
+  }
+}
+
+// One translation: one pair of foo,@foo entries from the template ARB file.
+//
+// The template ARB file must contain an entry called @myResourceId for each
+// message named myResourceId. The @ entry describes message parameters
+// called "placeholders" and can include an optional description.
+// Here's a simple example message with no parameters:
+//
+// "helloWorld": "Hello World",
+// "@helloWorld": {
+//   "description": "The conventional newborn programmer greeting"
+// }
+//
+// The value of this Message is "Hello World". The Message's value is the
+// localized string to be shown for the template ARB file's locale.
+// The docs for the Placeholder explain how placeholder entries are defined.
+class Message {
+  Message(Map<String, dynamic> bundle, this.resourceId)
+      : assert(bundle != null),
+        assert(resourceId != null && resourceId.isNotEmpty),
+        value = _value(bundle, resourceId),
+        description = _description(bundle, resourceId),
+        placeholders = _placeholders(bundle, resourceId),
+        _pluralMatch = _pluralRE.firstMatch(_value(bundle, resourceId));
+
+  static final RegExp _pluralRE = RegExp(r'\s*\{([\w\s,]*),\s*plural\s*,');
+
+  final String resourceId;
+  final String value;
+  final String description;
+  final List<Placeholder> placeholders;
+  final RegExpMatch _pluralMatch;
+
+  bool get isPlural => _pluralMatch != null && _pluralMatch.groupCount == 1;
+
+  bool get placeholdersRequireFormatting =>
+      placeholders.any((Placeholder p) => p.requiresFormatting);
+
+  Placeholder getCountPlaceholder() {
+    assert(isPlural);
+    final String countPlaceholderName = _pluralMatch[1];
+    return placeholders.firstWhere(
+        (Placeholder p) => p.name == countPlaceholderName, orElse: () {
+      throw L10nException(
+          'Cannot find the $countPlaceholderName placeholder in plural message "$resourceId".');
+    });
+  }
+
+  static String _value(Map<String, dynamic> bundle, String resourceId) {
+    final dynamic value = bundle[resourceId];
+    if (value == null)
+      throw L10nException('A value for resource "$resourceId" was not found.');
+    if (value is! String)
+      throw L10nException('The value of "$resourceId" is not a string.');
+    return bundle[resourceId] as String;
+  }
+
+  static Map<String, dynamic> _attributes(
+      Map<String, dynamic> bundle, String resourceId) {
+    final dynamic attributes = bundle['@$resourceId'];
+    if (attributes == null) {
+      throw L10nException(
+          'Resource attribute "@$resourceId" was not found. Please '
+          'ensure that each resource has a corresponding @resource.');
+    }
+    if (attributes is! Map<String, dynamic>) {
+      throw L10nException(
+          'The resource attribute "@$resourceId" is not a properly formatted Map. '
+          'Ensure that it is a map with keys that are strings.');
+    }
+    return attributes as Map<String, dynamic>;
+  }
+
+  static String _description(Map<String, dynamic> bundle, String resourceId) {
+    final dynamic value = _attributes(bundle, resourceId)['description'];
+    if (value == null) return null;
+    if (value is! String) {
+      throw L10nException(
+          'The description for "@$resourceId" is not a properly formatted String.');
+    }
+    return value as String;
+  }
+
+  static List<Placeholder> _placeholders(
+      Map<String, dynamic> bundle, String resourceId) {
+    final dynamic value = _attributes(bundle, resourceId)['placeholders'];
+    if (value == null) return <Placeholder>[];
+    if (value is! Map<String, dynamic>) {
+      throw L10nException(
+          'The "placeholders" attribute for message $resourceId, is not '
+          'properly formatted. Ensure that it is a map with string valued keys.');
+    }
+    final Map<String, dynamic> allPlaceholdersMap =
+        value as Map<String, dynamic>;
+    return allPlaceholdersMap.keys.map<Placeholder>((String placeholderName) {
+      final dynamic value = allPlaceholdersMap[placeholderName];
+      if (value is! Map<String, dynamic>) {
+        throw L10nException(
+            'The value of the "$placeholderName" placeholder attribute for message '
+            '"$resourceId", is not properly formatted. Ensure that it is a map '
+            'with string valued keys.');
+      }
+      return Placeholder(
+          resourceId, placeholderName, value as Map<String, dynamic>);
+    }).toList();
+  }
+}
+
+// Represents the contents of one ARB file.
+class AppResourceBundle {
+  factory AppResourceBundle(File file) {
+    assert(file != null);
+    // Assuming that the caller has verified that the file exists and is readable.
+
+    final Map<String, dynamic> resources =
+        json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+    String localeString = resources['@@locale'] as String;
+    if (localeString == null) {
+      final RegExp filenameRE = RegExp(r'^[^_]*_(\w+)\.arb$');
+      final RegExpMatch match = filenameRE.firstMatch(file.path);
+      localeString = match == null ? null : match[1];
+    }
+    if (localeString == null) {
+      throw L10nException(
+          "The following .arb file's locale could not be determined: \n"
+          '${file.path} \n'
+          "Make sure that the locale is specified in the file's '@@locale' "
+          'property or as part of the filename (e.g. file_en.arb)');
+    }
+
+    final Iterable<String> ids =
+        resources.keys.where((String key) => !key.startsWith('@'));
+    return AppResourceBundle._(
+        file, LocaleInfo.fromString(localeString), resources, ids);
+  }
+
+  const AppResourceBundle._(
+      this.file, this.locale, this.resources, this.resourceIds);
+
+  final File file;
+  final LocaleInfo locale;
+  final Map<String, dynamic> resources;
+  final Iterable<String> resourceIds;
+
+  String translationFor(Message message) =>
+      resources[message.resourceId] as String;
+
+  @override
+  String toString() {
+    return 'AppResourceBundle($locale, ${file.path})';
+  }
+}
+
+// Represents all of the ARB files in [directory] as [AppResourceBundle]s.
+class AppResourceBundleCollection {
+  factory AppResourceBundleCollection(Directory directory) {
+    assert(directory != null);
+    // Assuming that the caller has verified that the directory is readable.
+
+    final RegExp filenameRE = RegExp(r'(\w+)\.arb$');
+    final Map<LocaleInfo, AppResourceBundle> localeToBundle =
+        <LocaleInfo, AppResourceBundle>{};
+    final Map<String, List<LocaleInfo>> languageToLocales =
+        <String, List<LocaleInfo>>{};
+    final List<File> files = directory.listSync().whereType<File>().toList()
+      ..sort(sortFilesByPath);
+    for (final File file in files) {
+      if (filenameRE.hasMatch(file.path)) {
+        final AppResourceBundle bundle = AppResourceBundle(file);
+        if (localeToBundle[bundle.locale] != null) {
+          throw L10nException(
+              "Multiple arb files with the same '${bundle.locale}' locale detected. \n"
+              'Ensure that there is exactly one arb file for each locale.');
+        }
+        localeToBundle[bundle.locale] = bundle;
+        languageToLocales[bundle.locale.languageCode] ??= <LocaleInfo>[];
+        languageToLocales[bundle.locale.languageCode].add(bundle.locale);
+      }
+    }
+
+    languageToLocales.forEach(
+        (String language, List<LocaleInfo> listOfCorrespondingLocales) {
+      final List<String> localeStrings =
+          listOfCorrespondingLocales.map((LocaleInfo locale) {
+        return locale.toString();
+      }).toList();
+      if (!localeStrings.contains(language)) {
+        throw L10nException(
+            'Arb file for a fallback, $language, does not exist, even though \n'
+            'the following locale(s) exist: $listOfCorrespondingLocales. \n'
+            'When locales specify a script code or country code, a \n'
+            'base locale (without the script code or country code) should \n'
+            'exist as the fallback. Please create a {fileName}_$language.arb \n'
+            'file.');
+      }
+    });
+
+    return AppResourceBundleCollection._(
+        directory, localeToBundle, languageToLocales);
+  }
+
+  const AppResourceBundleCollection._(
+      this._directory, this._localeToBundle, this._languageToLocales);
+
+  final Directory _directory;
+  final Map<LocaleInfo, AppResourceBundle> _localeToBundle;
+  final Map<String, List<LocaleInfo>> _languageToLocales;
+
+  Iterable<LocaleInfo> get locales => _localeToBundle.keys;
+  Iterable<AppResourceBundle> get bundles => _localeToBundle.values;
+  AppResourceBundle bundleFor(LocaleInfo locale) => _localeToBundle[locale];
+
+  Iterable<String> get languages => _languageToLocales.keys;
+  Iterable<LocaleInfo> localesForLanguage(String language) =>
+      _languageToLocales[language] ?? <LocaleInfo>[];
+
+  @override
+  String toString() {
+    return 'AppResourceBundleCollection(${_directory.path}, ${locales.length} locales)';
+  }
+}

--- a/tools/gen_l10n_types.dart
+++ b/tools/gen_l10n_types.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 
 import 'localizations_utils.dart';
 
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 // The set of date formats that can be automatically localized.
 //
 // The localizations generation tool makes use of the intl library's

--- a/tools/localizations_utils.dart
+++ b/tools/localizations_utils.dart
@@ -1,0 +1,460 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/args.dart' as argslib;
+import 'package:meta/meta.dart';
+
+typedef HeaderGenerator = String Function(String regenerateInstructions);
+typedef ConstructorGenerator = String Function(LocaleInfo locale);
+
+int sortFilesByPath(FileSystemEntity a, FileSystemEntity b) {
+  return a.path.compareTo(b.path);
+}
+
+/// Simple data class to hold parsed locale. Does not promise validity of any data.
+class LocaleInfo implements Comparable<LocaleInfo> {
+  LocaleInfo({
+    this.languageCode,
+    this.scriptCode,
+    this.countryCode,
+    this.length,
+    this.originalString,
+  });
+
+  /// Simple parser. Expects the locale string to be in the form of 'language_script_COUNTRY'
+  /// where the language is 2 characters, script is 4 characters with the first uppercase,
+  /// and country is 2-3 characters and all uppercase.
+  ///
+  /// 'language_COUNTRY' or 'language_script' are also valid. Missing fields will be null.
+  ///
+  /// When `deriveScriptCode` is true, if [scriptCode] was unspecified, it will
+  /// be derived from the [languageCode] and [countryCode] if possible.
+  factory LocaleInfo.fromString(String locale,
+      {bool deriveScriptCode = false}) {
+    final List<String> codes = locale.split('_'); // [language, script, country]
+    assert(codes.isNotEmpty && codes.length < 4);
+    final String languageCode = codes[0];
+    String scriptCode;
+    String countryCode;
+    int length = codes.length;
+    String originalString = locale;
+    if (codes.length == 2) {
+      scriptCode = codes[1].length >= 4 ? codes[1] : null;
+      countryCode = codes[1].length < 4 ? codes[1] : null;
+    } else if (codes.length == 3) {
+      scriptCode = codes[1].length > codes[2].length ? codes[1] : codes[2];
+      countryCode = codes[1].length < codes[2].length ? codes[1] : codes[2];
+    }
+    assert(codes[0] != null && codes[0].isNotEmpty);
+    assert(countryCode == null || countryCode.isNotEmpty);
+    assert(scriptCode == null || scriptCode.isNotEmpty);
+
+    /// Adds scriptCodes to locales where we are able to assume it to provide
+    /// finer granularity when resolving locales.
+    ///
+    /// The basis of the assumptions here are based off of known usage of scripts
+    /// across various countries. For example, we know Taiwan uses traditional (Hant)
+    /// script, so it is safe to apply (Hant) to Taiwanese languages.
+    if (deriveScriptCode && scriptCode == null) {
+      switch (languageCode) {
+        case 'zh':
+          {
+            if (countryCode == null) {
+              scriptCode = 'Hans';
+            }
+            switch (countryCode) {
+              case 'CN':
+              case 'SG':
+                scriptCode = 'Hans';
+                break;
+              case 'TW':
+              case 'HK':
+              case 'MO':
+                scriptCode = 'Hant';
+                break;
+            }
+            break;
+          }
+        case 'sr':
+          {
+            if (countryCode == null) {
+              scriptCode = 'Cyrl';
+            }
+            break;
+          }
+      }
+      // Increment length if we were able to assume a scriptCode.
+      if (scriptCode != null) {
+        length += 1;
+      }
+      // Update the base string to reflect assumed scriptCodes.
+      originalString = languageCode;
+      if (scriptCode != null) originalString += '_' + scriptCode;
+      if (countryCode != null) originalString += '_' + countryCode;
+    }
+
+    return LocaleInfo(
+      languageCode: languageCode,
+      scriptCode: scriptCode,
+      countryCode: countryCode,
+      length: length,
+      originalString: originalString,
+    );
+  }
+
+  final String languageCode;
+  final String scriptCode;
+  final String countryCode;
+  final int length; // The number of fields. Ranges from 1-3.
+  final String originalString; // Original un-parsed locale string.
+
+  String camelCase() {
+    return originalString
+        .split('_')
+        .map<String>((String part) =>
+            part.substring(0, 1).toUpperCase() +
+            part.substring(1).toLowerCase())
+        .join('');
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is LocaleInfo && other.originalString == originalString;
+  }
+
+  @override
+  int get hashCode {
+    return originalString.hashCode;
+  }
+
+  @override
+  String toString() {
+    return originalString;
+  }
+
+  @override
+  int compareTo(LocaleInfo other) {
+    return originalString.compareTo(other.originalString);
+  }
+}
+
+/// Parse the data for a locale from a file, and store it in the [attributes]
+/// and [resources] keys.
+void loadMatchingArbsIntoBundleMaps({
+  @required Directory directory,
+  @required RegExp filenamePattern,
+  @required Map<LocaleInfo, Map<String, String>> localeToResources,
+  @required Map<LocaleInfo, Map<String, dynamic>> localeToResourceAttributes,
+}) {
+  assert(directory != null);
+  assert(filenamePattern != null);
+  assert(localeToResources != null);
+  assert(localeToResourceAttributes != null);
+
+  /// Set that holds the locales that were assumed from the existing locales.
+  ///
+  /// For example, when the data lacks data for zh_Hant, we will use the data of
+  /// the first Hant Chinese locale as a default by repeating the data. If an
+  /// explicit match is later found, we can reference this set to see if we should
+  /// overwrite the existing assumed data.
+  final Set<LocaleInfo> assumedLocales = <LocaleInfo>{};
+
+  for (final FileSystemEntity entity in directory.listSync().toList()
+    ..sort(sortFilesByPath)) {
+    final String entityPath = entity.path;
+    if (FileSystemEntity.isFileSync(entityPath) &&
+        filenamePattern.hasMatch(entityPath)) {
+      final String localeString = filenamePattern.firstMatch(entityPath)[1];
+      final File arbFile = File(entityPath);
+
+      // Helper method to fill the maps with the correct data from file.
+      void populateResources(LocaleInfo locale, File file) {
+        final Map<String, String> resources = localeToResources[locale];
+        final Map<String, dynamic> attributes =
+            localeToResourceAttributes[locale];
+        final Map<String, dynamic> bundle =
+            json.decode(file.readAsStringSync()) as Map<String, dynamic>;
+        for (final String key in bundle.keys) {
+          // The ARB file resource "attributes" for foo are called @foo.
+          if (key.startsWith('@'))
+            attributes[key.substring(1)] = bundle[key];
+          else
+            resources[key] = bundle[key] as String;
+        }
+      }
+
+      // Only pre-assume scriptCode if there is a country or script code to assume off of.
+      // When we assume scriptCode based on languageCode-only, we want this initial pass
+      // to use the un-assumed version as a base class.
+      LocaleInfo locale = LocaleInfo.fromString(localeString,
+          deriveScriptCode: localeString.split('_').length > 1);
+      // Allow overwrite if the existing data is assumed.
+      if (assumedLocales.contains(locale)) {
+        localeToResources[locale] = <String, String>{};
+        localeToResourceAttributes[locale] = <String, dynamic>{};
+        assumedLocales.remove(locale);
+      } else {
+        localeToResources[locale] ??= <String, String>{};
+        localeToResourceAttributes[locale] ??= <String, dynamic>{};
+      }
+      populateResources(locale, arbFile);
+      // Add an assumed locale to default to when there is no info on scriptOnly locales.
+      locale = LocaleInfo.fromString(localeString, deriveScriptCode: true);
+      if (locale.scriptCode != null) {
+        final LocaleInfo scriptLocale = LocaleInfo.fromString(
+            locale.languageCode + '_' + locale.scriptCode);
+        if (!localeToResources.containsKey(scriptLocale)) {
+          assumedLocales.add(scriptLocale);
+          localeToResources[scriptLocale] ??= <String, String>{};
+          localeToResourceAttributes[scriptLocale] ??= <String, dynamic>{};
+          populateResources(scriptLocale, arbFile);
+        }
+      }
+    }
+  }
+}
+
+void exitWithError(String errorMessage) {
+  assert(errorMessage != null);
+  stderr.writeln('fatal: $errorMessage');
+  exit(1);
+}
+
+void checkCwdIsRepoRoot(String commandName) {
+  final bool isRepoRoot = Directory('.git').existsSync();
+
+  if (!isRepoRoot) {
+    exitWithError(
+        '$commandName must be run from the root of the Flutter repository. The '
+        'current working directory is: ${Directory.current.path}');
+  }
+}
+
+GeneratorOptions parseArgs(List<String> rawArgs) {
+  final argslib.ArgParser argParser = argslib.ArgParser()
+    ..addFlag(
+      'overwrite',
+      abbr: 'w',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'material',
+      help:
+          'Whether to print the generated classes for the Material package only. Ignored when --overwrite is passed.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'cupertino',
+      help:
+          'Whether to print the generated classes for the Cupertino package only. Ignored when --overwrite is passed.',
+      defaultsTo: false,
+    );
+  final argslib.ArgResults args = argParser.parse(rawArgs);
+  final bool writeToFile = args['overwrite'] as bool;
+  final bool materialOnly = args['material'] as bool;
+  final bool cupertinoOnly = args['cupertino'] as bool;
+
+  return GeneratorOptions(
+      writeToFile: writeToFile,
+      materialOnly: materialOnly,
+      cupertinoOnly: cupertinoOnly);
+}
+
+class GeneratorOptions {
+  GeneratorOptions({
+    @required this.writeToFile,
+    @required this.materialOnly,
+    @required this.cupertinoOnly,
+  });
+
+  final bool writeToFile;
+  final bool materialOnly;
+  final bool cupertinoOnly;
+}
+
+const String registry =
+    'https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry';
+
+// See also //master/tools/gen_locale.dart in the engine repo.
+Map<String, List<String>> _parseSection(String section) {
+  final Map<String, List<String>> result = <String, List<String>>{};
+  List<String> lastHeading;
+  for (final String line in section.split('\n')) {
+    if (line == '') continue;
+    if (line.startsWith('  ')) {
+      lastHeading[lastHeading.length - 1] =
+          '${lastHeading.last}${line.substring(1)}';
+      continue;
+    }
+    final int colon = line.indexOf(':');
+    if (colon <= 0) throw 'not sure how to deal with "$line"';
+    final String name = line.substring(0, colon);
+    final String value = line.substring(colon + 2);
+    lastHeading = result.putIfAbsent(name, () => <String>[]);
+    result[name].add(value);
+  }
+  return result;
+}
+
+final Map<String, String> _languages = <String, String>{};
+final Map<String, String> _regions = <String, String>{};
+final Map<String, String> _scripts = <String, String>{};
+const String kProvincePrefix = ', Province of ';
+const String kParentheticalPrefix = ' (';
+
+/// Prepares the data for the [describeLocale] method below.
+///
+/// The data is obtained from the official IANA registry.
+Future<void> precacheLanguageAndRegionTags() async {
+  final HttpClient client = HttpClient();
+  final HttpClientRequest request = await client.getUrl(Uri.parse(registry));
+  final HttpClientResponse response = await request.close();
+  final String body = (await response
+          .cast<List<int>>()
+          .transform<String>(utf8.decoder)
+          .toList())
+      .join('');
+  client.close(force: true);
+  final List<Map<String, List<String>>> sections = body
+      .split('%%')
+      .skip(1)
+      .map<Map<String, List<String>>>(_parseSection)
+      .toList();
+  for (final Map<String, List<String>> section in sections) {
+    assert(section.containsKey('Type'), section.toString());
+    final String type = section['Type'].single;
+    if (type == 'language' || type == 'region' || type == 'script') {
+      assert(
+          section.containsKey('Subtag') && section.containsKey('Description'),
+          section.toString());
+      final String subtag = section['Subtag'].single;
+      String description = section['Description'].join(' ');
+      if (description.startsWith('United ')) description = 'the $description';
+      if (description.contains(kParentheticalPrefix))
+        description =
+            description.substring(0, description.indexOf(kParentheticalPrefix));
+      if (description.contains(kProvincePrefix))
+        description =
+            description.substring(0, description.indexOf(kProvincePrefix));
+      if (description.endsWith(' Republic')) description = 'the $description';
+      switch (type) {
+        case 'language':
+          _languages[subtag] = description;
+          break;
+        case 'region':
+          _regions[subtag] = description;
+          break;
+        case 'script':
+          _scripts[subtag] = description;
+          break;
+      }
+    }
+  }
+}
+
+String describeLocale(String tag) {
+  final List<String> subtags = tag.split('_');
+  assert(subtags.isNotEmpty);
+  assert(_languages.containsKey(subtags[0]));
+  final String language = _languages[subtags[0]];
+  String output = language;
+  String region;
+  String script;
+  if (subtags.length == 2) {
+    region = _regions[subtags[1]];
+    script = _scripts[subtags[1]];
+    assert(region != null || script != null);
+  } else if (subtags.length >= 3) {
+    region = _regions[subtags[2]];
+    script = _scripts[subtags[1]];
+    assert(region != null && script != null);
+  }
+  if (region != null) output += ', as used in $region';
+  if (script != null) output += ', using the $script script';
+  return output;
+}
+
+/// Writes the header of each class which corresponds to a locale.
+String generateClassDeclaration(
+  LocaleInfo locale,
+  String classNamePrefix,
+  String superClass,
+) {
+  final String camelCaseName = locale.camelCase();
+  return '''
+
+/// The translations for ${describeLocale(locale.originalString)} (`${locale.originalString}`).
+class $classNamePrefix$camelCaseName extends $superClass {''';
+}
+
+/// Return the input string as a Dart-parseable string.
+///
+/// ```
+/// foo => 'foo'
+/// foo "bar" => 'foo "bar"'
+/// foo 'bar' => "foo 'bar'"
+/// foo 'bar' "baz" => '''foo 'bar' "baz"'''
+/// foo\bar => 'foo\\bar'
+/// foo\nbar => 'foo\\\\nbar'
+/// ```
+///
+/// When [shouldEscapeDollar] is set to true, the
+/// result avoids character escaping, with the
+/// exception of the dollar sign:
+///
+/// ```
+/// foo$bar = 'foo\$bar'
+/// ```
+///
+/// When [shouldEscapeDollar] is set to false, the
+/// result tries to avoid character escaping:
+///
+/// ```
+/// foo$bar => 'foo\\\$bar'
+/// ```
+///
+/// [shouldEscapeDollar] is true by default.
+///
+/// Strings with newlines are not supported.
+String generateString(String value, {bool escapeDollar = true}) {
+  assert(escapeDollar != null);
+  assert(
+      !value.contains('\n'),
+      'Since it is assumed that the input string comes '
+      'from a json/arb file source, messages cannot '
+      'contain newlines.');
+
+  const String backslash = '__BACKSLASH__';
+  assert(
+      !value.contains(backslash),
+      'Input string cannot contain the sequence: '
+      '"__BACKSLASH__", as it is used as part of '
+      'backslash character processing.');
+  value = value.replaceAll('\\', backslash);
+
+  if (escapeDollar) value = value.replaceAll('\$', '\\\$');
+
+  value = value
+      .replaceAll("'", "\\'")
+      .replaceAll('"', '\\"')
+      .replaceAll(backslash, '\\\\');
+
+  return "'$value'";
+}
+
+/// Only used to generate localization strings for the Kannada locale ('kn') because
+/// some of the localized strings contain characters that can crash Emacs on Linux.
+/// See packages/flutter_localizations/lib/src/l10n/README for more information.
+String generateEncodedString(String locale, String value) {
+  if (locale != 'kn' || value.runes.every((int code) => code <= 0xFF))
+    return generateString(value);
+
+  final String unicodeEscapes =
+      value.runes.map((int code) => '\\u{${code.toRadixString(16)}}').join();
+  return "'$unicodeEscapes'";
+}

--- a/tools/localizations_utils.dart
+++ b/tools/localizations_utils.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:args/args.dart' as argslib;
 import 'package:meta/meta.dart';
 
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 typedef HeaderGenerator = String Function(String regenerateInstructions);
 typedef ConstructorGenerator = String Function(LocaleInfo locale);
 


### PR DESCRIPTION
This app's AppLocalization class was generated with the Flutter beta version of the gen_l10n tool. Many developers are still adding and modifying messages (user visible text strings) and will need a way to update the AppLocalization class themselves.

This can be done by running the local copy of the gen_l10n tool:
```dart
${FLUTTER_HOME}/bin/cache/dart-sdk/bin/dart tools/gen_l10n.dart --arb-dir lib/src/l10n
```
Where FLUTTER_HOME is your copy of Flutter.

When this app has moved on to Flutter's beta release, this copy of gen_l10n can be removed.