### PR TITLE
[testing] standardize setup pattern

### DIFF
--- a/test/image_tests.dart
+++ b/test/image_tests.dart
@@ -16,9 +16,6 @@ void main() {
   setUp(() async {
     BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
         storageDirectory: MemoryFileSystem.test().currentDirectory);
-  });
-
-  setUp(() async {
     await _loadRobotoFont();
 
     binding.window.physicalSizeTestValue = Size(500, 800);

--- a/test/image_tests.dart
+++ b/test/image_tests.dart
@@ -2,25 +2,23 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:covidnearme/src/app.dart';
+import 'package:covidnearme/src/blocs/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:file/memory.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
+
   setUp(() async {
-    // Use a hermetic file system that is cleaned up between tests.
-    final fs = MemoryFileSystem.test();
+    BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
+        storageDirectory: MemoryFileSystem.test().currentDirectory);
+  });
 
-    BlocSupervisor.delegate = await HydratedBlocDelegate.build(
-      storageDirectory: fs.systemTempDirectory.createTempSync(),
-    );
-
+  setUp(() async {
     await _loadRobotoFont();
 
     binding.window.physicalSizeTestValue = Size(500, 800);

--- a/test/ui/screens/checkup_test.dart
+++ b/test/ui/screens/checkup_test.dart
@@ -1,6 +1,7 @@
 import 'package:covidnearme/src/blocs/checkup/checkup.dart';
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
 import 'package:covidnearme/src/blocs/questions/questions_bloc.dart';
+import 'package:covidnearme/src/blocs/utils.dart';
 import 'package:covidnearme/src/data/repositories/checkups.dart';
 import 'package:covidnearme/src/data/repositories/questions.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
@@ -10,16 +11,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 void main() {
   setUp(() async {
-    // Use a hermetic file system that is cleaned up between tests.
-    final fs = MemoryFileSystem.test();
-
-    BlocSupervisor.delegate = await HydratedBlocDelegate.build(
-      storageDirectory: fs.systemTempDirectory.createTempSync(),
-    );
+    BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
+        storageDirectory: MemoryFileSystem.test().currentDirectory);
   });
 
   testWidgets('CheckupScreen transitions from loading to health checkup',
@@ -37,7 +33,7 @@ void main() {
 
   testWidgets('Cannot advance to the next screen by scrolling', (tester) async {
     const String page1 = "It's time for your checkup.";
-    const String page2 = "Step 1 of 2";
+    const String page2 = "Step 1 of 3";
 
     await tester.pumpWidget(setUpCheckupScreen());
     await tester.pumpAndSettle();

--- a/test/ui/widgets/questions_test.dart
+++ b/test/ui/widgets/questions_test.dart
@@ -1,12 +1,20 @@
 import 'package:covidnearme/src/blocs/questions/questions.dart';
+import 'package:covidnearme/src/blocs/utils.dart';
 import 'package:covidnearme/src/ui/widgets/questions/inputs/simple_slider.dart';
 import 'package:covidnearme/src/ui/widgets/questions/question_item.dart';
+import 'package:file/memory.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  setUp(() async {
+    BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
+        storageDirectory: MemoryFileSystem.test().currentDirectory);
+  });
+
   testWidgets('QuestionItem displays question values for non-SliderQuestion',
       (tester) async {
     await tester.pumpWidget(

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,19 +1,13 @@
+import 'package:covidnearme/src/blocs/utils.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:covidnearme/src/app.dart';
 import 'package:file/memory.dart';
-import 'package:hydrated_bloc/hydrated_bloc.dart';
 
 void main() {
-  MemoryFileSystem fs;
   setUp(() async {
-    // Use a hermetic file system that is cleaned up between tests.
-    fs = MemoryFileSystem.test();
-
-    BlocSupervisor.delegate = await HydratedBlocDelegate.build(
-      storageDirectory: fs.systemTempDirectory.createTempSync(),
-    );
+    BlocSupervisor.delegate = await AppHydratedBlocDelegate.build(
+        storageDirectory: MemoryFileSystem.test().currentDirectory);
   });
 
   testWidgets('App loads test', (WidgetTester tester) async {


### PR DESCRIPTION
Standardize the `setUp` pattern to use the bloc delegate which delegates to FlutterError and simplifies the memory filesystem usage.