### PR TITLE
Fix spacing around checkup questions page

### DIFF
--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -71,30 +71,33 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
         return BlocBuilder<QuestionsBloc, QuestionsState>(
           builder: (context, state) {
             final QuestionsState questionsState = state;
-            return Stack(
+            return Column(
+              mainAxisSize: MainAxisSize.max,
               children: <Widget>[
-                PageView.builder(
-                  physics: NeverScrollableScrollPhysics(),
-                  controller: Provider.of<PageController>(context),
-                  onPageChanged: (int index) => _handlePageChange(
-                    index,
-                    checkupState,
-                    questionsState,
-                  ),
-                  itemCount: steps.length,
-                  itemBuilder: (BuildContext context, int index) {
-                    return steps[index];
-                  },
-                ),
                 AnimatedSwitcher(
                   duration: const Duration(milliseconds: 200),
                   child: currentStep != null && currentIndex > 0
                       ? CheckupProgressBar(
-                          currentIndex: currentIndex,
-                          // Subtract one because the intro isn't really a step.
-                          stepsLength: steps.length - 1,
-                        )
-                      : null,
+                    currentIndex: currentIndex,
+                    // Subtract one because the intro isn't really a step.
+                    stepsLength: steps.length - 1,
+                  )
+                      : Container(),
+                ),
+                Expanded(
+                  child: PageView.builder(
+                    physics: NeverScrollableScrollPhysics(),
+                    controller: Provider.of<PageController>(context),
+                    onPageChanged: (int index) => _handlePageChange(
+                      index,
+                      checkupState,
+                      questionsState,
+                    ),
+                    itemCount: steps.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      return steps[index];
+                    },
+                  ),
                 ),
               ],
             );

--- a/lib/src/ui/screens/checkup/checkup_loaded_body.dart
+++ b/lib/src/ui/screens/checkup/checkup_loaded_body.dart
@@ -72,16 +72,15 @@ class _CheckupLoadedBodyState extends State<CheckupLoadedBody> {
           builder: (context, state) {
             final QuestionsState questionsState = state;
             return Column(
-              mainAxisSize: MainAxisSize.max,
               children: <Widget>[
                 AnimatedSwitcher(
                   duration: const Duration(milliseconds: 200),
                   child: currentStep != null && currentIndex > 0
                       ? CheckupProgressBar(
-                    currentIndex: currentIndex,
-                    // Subtract one because the intro isn't really a step.
-                    stepsLength: steps.length - 1,
-                  )
+                          currentIndex: currentIndex,
+                          // Subtract one because the intro isn't really a step.
+                          stepsLength: steps.length - 1,
+                        )
                       : Container(),
                 ),
                 Expanded(

--- a/lib/src/ui/screens/checkup/steps/subjective.dart
+++ b/lib/src/ui/screens/checkup/steps/subjective.dart
@@ -66,7 +66,6 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
           builder: (context, state) {
             final CheckupStateInProgress checkupState = state;
             return QuestionView(
-              padding: EdgeInsets.only(top: 20, bottom: 80),
               questions: questionState.questions,
               onChange: (Question question, dynamic value) =>
                   _updateCheckup(question, value, checkupState),

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -46,6 +46,7 @@ class _QuestionViewState extends State<QuestionView> {
           children: [
             ..._getQuestions(),
             StepFinishedButton(),
+            SizedBox(height: 20),
           ],
         ),
       ),


### PR DESCRIPTION
* Use a column instead of a stack for the progress bar and main checkup page content
* Remove padding from the container of the scrollview for the main content

closes https://github.com/coronavirus-diary/coronavirus-diary/issues/110

Before:

![Screen Shot 2020-03-24 at 4 44 31 PM](https://user-images.githubusercontent.com/591699/77477742-2e54a080-6df3-11ea-85bf-d918a4718c73.png)
![Screen Shot 2020-03-24 at 4 44 46 PM](https://user-images.githubusercontent.com/591699/77477745-2f85cd80-6df3-11ea-810d-6e7b2a056cd2.png)

After:

![Screen Shot 2020-03-24 at 5 11 35 PM](https://user-images.githubusercontent.com/591699/77477769-39a7cc00-6df3-11ea-9c33-9951bdd0b604.png)
![Screen Shot 2020-03-24 at 5 11 21 PM](https://user-images.githubusercontent.com/591699/77477775-3c0a2600-6df3-11ea-9b96-7834e455d8c8.png)
