### PR TITLE
Give more space to label elements so they dont overflo…

### DIFF
--- a/lib/src/ui/widgets/questions/inputs/simple_slider.dart
+++ b/lib/src/ui/widgets/questions/inputs/simple_slider.dart
@@ -53,11 +53,18 @@ class _SimpleSliderState extends State<SimpleSlider> {
     for (int i = 0; i <= divisions; i++) {
       String label = labels[i.toString()];
       if (label == null) {
-        bottomLabelsChildren.add(Spacer());
+        bottomLabelsChildren.add(Spacer(
+          flex: 9,
+        ));
       } else {
         bottomLabelsChildren.add(
           Expanded(
-            child: Center(child: Text(label)),
+            flex: 10,
+            child: Center(
+                child: Text(
+              label,
+              textAlign: TextAlign.center,
+            )),
           ),
         );
       }


### PR DESCRIPTION
Fixes #116 

Before: (see right most labels on the slider)
![before](https://user-images.githubusercontent.com/5570900/77483114-a63cbe00-6e27-11ea-85b7-1080ef912149.png)

After:
![after](https://user-images.githubusercontent.com/5570900/77483116-a76deb00-6e27-11ea-85e3-74e7ffe13e26.png)
