### PR TITLE
Updated localizations, removed async loading of consent markdown files

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1,45 +1,71 @@
 {
   "@@locale": "en",
+
+  "consentStepQuestion": "# Informed Consent\n\nSince the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.\n\nYou are anonymous. We don’t want to know who you are! We will ask for your zip code to count cases around specific hospitals. Your symptom severity will be used to guess how likely it is that you have COVID-19, and to see how many people in your region are becoming severely sick.\n\nTotal daily cases for zip codes will be provided to state and local health authorities, the CDC, and the US Government to help predict which communities need the most support. We will also make a map here on this app. Data will also be analyzed for geographic trends. For example, we might see fewer cases in areas that closed schools for a long time, or perhaps we will see that the epidemic slows down in hot weather.\n\nYou can come back later and enter new information on a different day. We will know it’s you and won’t count you twice. Maybe you feel a lot worse, or you got a COVID-19 test result and would like to let us know.\n\nWe will not sell this data. It will only be used for public health and research and deleted after the epidemic has run its course.\n\nIf this is all OK and you are 18 years old or older, please click \"I agree\". Otherwise, click \"No\".",
+  "@consentStepQuestion": {
+    "description": "The long informed consent question asked of users"
+  },
+
+  "deniedConsentHeading": "Consent denied",
+  "@deniedConsentHeading":  {
+    "description": "Heading for the page show reminds the user that they've said no"
+  },
+
+  "deniedConsentMessage": "We need you to grant the App consent to perform the required action.",
+  "@deniedConsentMessage":  {
+    "description": "The app's response if the user does not agree to the informed consent question"
+  },
+
   "assessmentScreenTitle": "Your Personalized Assessment",
   "@assessmentScreenTitle": {
     "description": "The title of the AssessmentScreen"
   },
+
   "negativeAssessmentTestingCriteria": "You don't meet testing criteria",
   "@negativeAssessmentTestingCriteria": {
     "description": "The patient does not require further testing"
   },
+
   "negativeAssessmentCheckInTomorrow": "If you continue to experience symptoms, please check in tomorrow.",
   "@negativeAssessmentCheckInTomorrow": {
     "description": "The patient should check in again tomorrow"
   },
+
   "negativeAssessmentConsultPhysician": "If they become serious, please consult a physician.",
   "@negativeAssessmentConsultPhysician": {
     "description": "Advise the patient to consult a doctor if their symptoms worsen"
   },
+
   "positiveAssessmentConsultPhysician": "Please contact your physician",
   "@positiveAssessmentConsultPhysician": {
     "description": "Advise the patient to consult a doctor"
   },
+
   "positiveAssessmentShowingSymptoms": "You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.",
   "@positiveAssessmentShowingSymptoms": {
     "description": "Advise the patient to avoid contact with others until they've seen a doctor"
   },
+
   "positiveAssessmentDoNotPanic":  "Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.",
   "@positiveAssessmentDoNotPanic": {
     "description": "Advise the patient to remain calm"
   },
+
   "checkupScreenErrorRetrievingExperience": "There was an error retrieving the checkup experience. Please try again later.",
   "@checkupScreenErrorRetrievingExperience": {
     "description": "An error occurred while trying to fetch data"
   },
+
   "checkupScreenHUDLabel": "Loading your assessment",
   "@checkupScreenHUDLabel": {
     "description": "A label that indicates that the app is busy loading the patient's assessment"
   },
+
   "checkupScreenTitle": "Your Health Checkup",
   "@checkupScreenTitle": {
     "description": "Title for the checkup screen"
   },
+
   "checkupProgressBarPercentCompleteText": "Step {stepIndex} of {stepCount}",
   "@checkupProgressBarPercentCompleteText": {
     "description": "Which step in the overall process is the patient currently working on",
@@ -463,5 +489,10 @@
   "questionHaveAFeverSemantics4": "I'm burning up",
   "@questionHaveAFeverSemantics4": {
     "description": "Question accessibility semantics description."
+  },
+
+  "scrollMoreIndicatorMessage": "SCROLL FOR MORE",
+  "@scrollMoreIndicatorMessage": {
+    "description": "Let the user that they can scroll to see more content"
   }
 }

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -1,3 +1,4 @@
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -63,9 +64,7 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-      : assert(locale != null),
-        localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
@@ -74,8 +73,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -87,8 +85,7 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -96,7 +93,18 @@ abstract class AppLocalizations {
   ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en')
+  ];
+
+  // The long informed consent question asked of users
+  String get consentStepQuestion;
+
+  // Heading for the page show reminds the user that they've said no
+  String get deniedConsentHeading;
+
+  // The app's response if the user does not agree to the informed consent question
+  String get deniedConsentMessage;
 
   // The title of the AssessmentScreen
   String get assessmentScreenTitle;
@@ -370,10 +378,12 @@ abstract class AppLocalizations {
 
   // Question accessibility semantics description.
   String get questionHaveAFeverSemantics4;
+
+  // Let the user that they can scroll to see more content
+  String get scrollMoreIndicatorMessage;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -382,19 +392,16 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations _lookupAppLocalizations(Locale locale) {
-  switch (locale.languageCode) {
-    case 'en':
-      return AppLocalizationsEn();
+  switch(locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
   }
-  assert(false,
-      'AppLocalizations.delegate failed to load unsupported locale "$locale"');
+  assert(false, 'AppLocalizations.delegate failed to load unsupported locale "$locale"');
   return null;
 }

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -64,7 +63,9 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+      : assert(locale != null),
+        localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
@@ -73,7 +74,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -85,7 +87,8 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -93,9 +96,7 @@ abstract class AppLocalizations {
   ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[
-    Locale('en')
-  ];
+  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
   // The long informed consent question asked of users
   String get consentStepQuestion;
@@ -383,7 +384,8 @@ abstract class AppLocalizations {
   String get scrollMoreIndicatorMessage;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -392,16 +394,19 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations _lookupAppLocalizations(Locale locale) {
-  switch(locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
   }
-  assert(false, 'AppLocalizations.delegate failed to load unsupported locale "$locale"');
+  assert(false,
+      'AppLocalizations.delegate failed to load unsupported locale "$locale"');
   return null;
 }

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -1,3 +1,4 @@
+
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -9,35 +10,49 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get consentStepQuestion => '''# Informed Consent
+
+Since the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.
+
+You are anonymous. We don’t want to know who you are! We will ask for your zip code to count cases around specific hospitals. Your symptom severity will be used to guess how likely it is that you have COVID-19, and to see how many people in your region are becoming severely sick.
+
+Total daily cases for zip codes will be provided to state and local health authorities, the CDC, and the US Government to help predict which communities need the most support. We will also make a map here on this app. Data will also be analyzed for geographic trends. For example, we might see fewer cases in areas that closed schools for a long time, or perhaps we will see that the epidemic slows down in hot weather.
+
+You can come back later and enter new information on a different day. We will know it’s you and won’t count you twice. Maybe you feel a lot worse, or you got a COVID-19 test result and would like to let us know.
+
+We will not sell this data. It will only be used for public health and research and deleted after the epidemic has run its course.
+
+If this is all OK and you are 18 years old or older, please click \"I agree\". Otherwise, click \"No\".''';
+
+  @override
+  String get deniedConsentHeading => 'Consent denied';
+
+  @override
+  String get deniedConsentMessage => 'We need you to grant the App consent to perform the required action.';
+
+  @override
   String get assessmentScreenTitle => 'Your Personalized Assessment';
 
   @override
-  String get negativeAssessmentTestingCriteria =>
-      'You don\'t meet testing criteria';
+  String get negativeAssessmentTestingCriteria => 'You don\'t meet testing criteria';
 
   @override
-  String get negativeAssessmentCheckInTomorrow =>
-      'If you continue to experience symptoms, please check in tomorrow.';
+  String get negativeAssessmentCheckInTomorrow => 'If you continue to experience symptoms, please check in tomorrow.';
 
   @override
-  String get negativeAssessmentConsultPhysician =>
-      'If they become serious, please consult a physician.';
+  String get negativeAssessmentConsultPhysician => 'If they become serious, please consult a physician.';
 
   @override
-  String get positiveAssessmentConsultPhysician =>
-      'Please contact your physician';
+  String get positiveAssessmentConsultPhysician => 'Please contact your physician';
 
   @override
-  String get positiveAssessmentShowingSymptoms =>
-      'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
+  String get positiveAssessmentShowingSymptoms => 'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
 
   @override
-  String get positiveAssessmentDoNotPanic =>
-      'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
+  String get positiveAssessmentDoNotPanic => 'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
 
   @override
-  String get checkupScreenErrorRetrievingExperience =>
-      'There was an error retrieving the checkup experience. Please try again later.';
+  String get checkupScreenErrorRetrievingExperience => 'There was an error retrieving the checkup experience. Please try again later.';
 
   @override
   String get checkupScreenHUDLabel => 'Loading your assessment';
@@ -47,14 +62,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String checkupProgressBarPercentCompleteText(int stepIndex, int stepCount) {
-    final intl.NumberFormat stepIndexNumberFormat =
-        intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepIndexNumberFormat = intl.NumberFormat.compactLong(
       locale: localeName,
+      
     );
     final String stepIndexString = stepIndexNumberFormat.format(stepIndex);
-    final intl.NumberFormat stepCountNumberFormat =
-        intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepCountNumberFormat = intl.NumberFormat.compactLong(
       locale: localeName,
+      
     );
     final String stepCountString = stepCountNumberFormat.format(stepCount);
 
@@ -68,79 +83,64 @@ class AppLocalizationsEn extends AppLocalizations {
   String get checkupStepFinishedNext => 'NEXT';
 
   @override
-  String get checkupStepFinishedAnswerAllQuestions =>
-      'Please answer all the questions to continue';
+  String get checkupStepFinishedAnswerAllQuestions => 'Please answer all the questions to continue';
 
   @override
   String get introStepTimeForYourCheckup => 'It\'s time for your checkup.';
 
   @override
-  String get introStepWeWillAskQuestions =>
-      'We will ask you a few questions and have you take your temperature.';
+  String get introStepWeWillAskQuestions => 'We will ask you a few questions and have you take your temperature.';
 
   @override
-  String get introStepAtTheEnd =>
-      'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
+  String get introStepAtTheEnd => 'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
 
   @override
-  String get introStepSwitchLabelContributeData =>
-      'Contribute my data to the COVID-19 response effort.';
+  String get introStepSwitchLabelContributeData => 'Contribute my data to the COVID-19 response effort.';
 
   @override
-  String get introStepSwitchLabelCollectPostalCode =>
-      'We will collect your zip code.';
+  String get introStepSwitchLabelCollectPostalCode => 'We will collect your zip code.';
 
   @override
   String get introStepButtonStartLabel => 'START CHECKUP';
 
   @override
-  String get subjectiveStepQuestionsLoadedError =>
-      'Questions could not be loaded.';
+  String get subjectiveStepQuestionsLoadedError => 'Questions could not be loaded.';
 
   @override
   String get temperatureStepWhenHeading => 'When?';
 
   @override
-  String get temperatureStepWait30Minutes =>
-      'Wait 30 minutes after eating, drinking, or exercising';
+  String get temperatureStepWait30Minutes => 'Wait 30 minutes after eating, drinking, or exercising';
 
   @override
-  String get temperatureStepWait6Hours =>
-      'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
+  String get temperatureStepWait6Hours => 'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
 
   @override
   String get temperatureStepHowHeading => 'How?';
 
   @override
-  String get temperatureStepPleaseEnterValueBelow =>
-      'Please enter a value below 150 ℉';
+  String get temperatureStepPleaseEnterValueBelow => 'Please enter a value below 150 ℉';
 
   @override
-  String get temperatureStepPleaseEnterValueAbove =>
-      'Please enter a value above 70 ℉';
+  String get temperatureStepPleaseEnterValueAbove => 'Please enter a value above 70 ℉';
 
   @override
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
-  String get temperatureStepHowToDialogStep1 =>
-      'Wash your hands using soap and water';
+  String get temperatureStepHowToDialogStep1 => 'Wash your hands using soap and water';
 
   @override
-  String get temperatureStepHowToDialogStep2 =>
-      'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
+  String get temperatureStepHowToDialogStep2 => 'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
 
   @override
-  String get temperatureStepHowToDialogStep3 =>
-      'Put the tip of your thermometer under your tongue and gently close your lips.';
+  String get temperatureStepHowToDialogStep3 => 'Put the tip of your thermometer under your tongue and gently close your lips.';
 
   @override
-  String get temperatureStepHowToDialogStep4 =>
-      'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
+  String get temperatureStepHowToDialogStep4 => 'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
 
   @override
-  String get temperatureStepHowToDialogStep5 =>
-      'Take out your thermometer and record your temperature.';
+  String get temperatureStepHowToDialogStep5 => 'Take out your thermometer and record your temperature.';
 
   @override
   String get temperatureStepHowToDialogReturn => 'RETURN TO CHECKUP';
@@ -158,33 +158,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeScreenHeading => 'Concerned about your health?';
 
   @override
-  String get homeScreenDoYouHaveSymptoms =>
-      'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
+  String get homeScreenDoYouHaveSymptoms => 'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
 
   @override
   String get homeScreenCheckupButtonLabel => 'START HEALTH CHECKUP';
 
   @override
-  String get homeScreenYouHaveCompletedCheckup =>
-      'You have completed your checkup for today!';
+  String get homeScreenYouHaveCompletedCheckup => 'You have completed your checkup for today!';
 
   @override
-  String get homeScreenCheckBackTomorrow =>
-      'If you continue to experience symptoms, please check back tomorrow.';
+  String get homeScreenCheckBackTomorrow => 'If you continue to experience symptoms, please check back tomorrow.';
 
   @override
   String get homeScreenViewMyAssessment => 'View my assessment';
 
   @override
-  String get shareAppDownloadPrompt =>
-      'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
+  String get shareAppDownloadPrompt => 'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
 
   @override
   String get shareAppProtectYourCommunity => 'Protect Your Community';
 
   @override
-  String get shareAppWithFriendsEtc =>
-      'Share this app with your friends, coworkers, and family (especially grandparents).';
+  String get shareAppWithFriendsEtc => 'Share this app with your friends, coworkers, and family (especially grandparents).';
 
   @override
   String get shareAppNow => 'SHARE NOW';
@@ -199,19 +194,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get staySafeLimitContact => 'Limit contact with other people.';
 
   @override
-  String get staySafeCheckBackIf =>
-      'Check back in if you continue to experience symptoms.';
+  String get staySafeCheckBackIf => 'Check back in if you continue to experience symptoms.';
 
   @override
   String get tutorialIntroStepWelcome => 'Welcome to the CovidNearMe App';
 
   @override
-  String get tutorialIntroStepCompleteACheckup =>
-      'Complete a daily health checkup.';
+  String get tutorialIntroStepCompleteACheckup => 'Complete a daily health checkup.';
 
   @override
-  String get tutorialIntroStepReceiveAssessment =>
-      'Receive a personalized health assessment.';
+  String get tutorialIntroStepReceiveAssessment => 'Receive a personalized health assessment.';
 
   @override
   String get tutorialIntroStepAidEffort => 'Aid COVID-19 response efforts.';
@@ -220,8 +212,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tutorialIntroStepLearnMore => 'LEARN MORE';
 
   @override
-  String get getStartedStepJoined =>
-      'You\'ve joined the CovidNearMe community!';
+  String get getStartedStepJoined => 'You\'ve joined the CovidNearMe community!';
 
   @override
   String get consentStepDidNotAgree => 'DID NOT AGREE';
@@ -245,20 +236,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get networkUnavailableBannerConnectToWiFi => 'CONNECT TO WIFI';
 
   @override
-  String get networkUnavailableBannerMessage =>
-      'You seem to be offline. Please check your network settings and try again.';
+  String get networkUnavailableBannerMessage => 'You seem to be offline. Please check your network settings and try again.';
 
   @override
-  String get deniedConsentBackButton =>
-      'Go back to the informed consent screen';
+  String get deniedConsentBackButton => 'Go back to the informed consent screen';
 
   @override
-  String get questionShortnessOfBreathTitle =>
-      'Are you experiencing shortness of breath?';
+  String get questionShortnessOfBreathTitle => 'Are you experiencing shortness of breath?';
 
   @override
-  String get questionShortnessOfBreathSubtitle =>
-      'Do you feel like you can\'t get enough air?';
+  String get questionShortnessOfBreathSubtitle => 'Do you feel like you can\'t get enough air?';
 
   @override
   String get questionShortnessOfBreathAnswer0 => 'I can breathe fine';
@@ -270,20 +257,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get questionShortnessOfBreathSemantics0 => 'I can breathe fine';
 
   @override
-  String get questionShortnessOfBreathSemantics1 =>
-      'I have a little trouble breathing';
+  String get questionShortnessOfBreathSemantics1 => 'I have a little trouble breathing';
 
   @override
-  String get questionShortnessOfBreathSemantics2 =>
-      'I have some trouble breathing';
+  String get questionShortnessOfBreathSemantics2 => 'I have some trouble breathing';
 
   @override
-  String get questionShortnessOfBreathSemantics3 =>
-      'It is difficult to breathe';
+  String get questionShortnessOfBreathSemantics3 => 'It is difficult to breathe';
 
   @override
-  String get questionShortnessOfBreathSemantics4 =>
-      'I can hardly breathe at all';
+  String get questionShortnessOfBreathSemantics4 => 'I can hardly breathe at all';
 
   @override
   String get questionHaveACoughTitle => 'Do you have a cough?';
@@ -310,8 +293,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get questionHaveACoughSemantics4 => 'Constantly';
 
   @override
-  String get questionHaveAFeverTitle =>
-      'Have you felt like you\'ve had a fever?';
+  String get questionHaveAFeverTitle => 'Have you felt like you\'ve had a fever?';
 
   @override
   String get questionHaveAFeverAnswer0 => 'No';
@@ -333,4 +315,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get questionHaveAFeverSemantics4 => 'I\'m burning up';
+
+  @override
+  String get scrollMoreIndicatorMessage => 'SCROLL FOR MORE';
 }

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -1,4 +1,3 @@
-
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -28,31 +27,39 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get deniedConsentHeading => 'Consent denied';
 
   @override
-  String get deniedConsentMessage => 'We need you to grant the App consent to perform the required action.';
+  String get deniedConsentMessage =>
+      'We need you to grant the App consent to perform the required action.';
 
   @override
   String get assessmentScreenTitle => 'Your Personalized Assessment';
 
   @override
-  String get negativeAssessmentTestingCriteria => 'You don\'t meet testing criteria';
+  String get negativeAssessmentTestingCriteria =>
+      'You don\'t meet testing criteria';
 
   @override
-  String get negativeAssessmentCheckInTomorrow => 'If you continue to experience symptoms, please check in tomorrow.';
+  String get negativeAssessmentCheckInTomorrow =>
+      'If you continue to experience symptoms, please check in tomorrow.';
 
   @override
-  String get negativeAssessmentConsultPhysician => 'If they become serious, please consult a physician.';
+  String get negativeAssessmentConsultPhysician =>
+      'If they become serious, please consult a physician.';
 
   @override
-  String get positiveAssessmentConsultPhysician => 'Please contact your physician';
+  String get positiveAssessmentConsultPhysician =>
+      'Please contact your physician';
 
   @override
-  String get positiveAssessmentShowingSymptoms => 'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
+  String get positiveAssessmentShowingSymptoms =>
+      'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
 
   @override
-  String get positiveAssessmentDoNotPanic => 'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
+  String get positiveAssessmentDoNotPanic =>
+      'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
 
   @override
-  String get checkupScreenErrorRetrievingExperience => 'There was an error retrieving the checkup experience. Please try again later.';
+  String get checkupScreenErrorRetrievingExperience =>
+      'There was an error retrieving the checkup experience. Please try again later.';
 
   @override
   String get checkupScreenHUDLabel => 'Loading your assessment';
@@ -62,14 +69,14 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
 
   @override
   String checkupProgressBarPercentCompleteText(int stepIndex, int stepCount) {
-    final intl.NumberFormat stepIndexNumberFormat = intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepIndexNumberFormat =
+        intl.NumberFormat.compactLong(
       locale: localeName,
-      
     );
     final String stepIndexString = stepIndexNumberFormat.format(stepIndex);
-    final intl.NumberFormat stepCountNumberFormat = intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepCountNumberFormat =
+        intl.NumberFormat.compactLong(
       locale: localeName,
-      
     );
     final String stepCountString = stepCountNumberFormat.format(stepCount);
 
@@ -83,64 +90,79 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get checkupStepFinishedNext => 'NEXT';
 
   @override
-  String get checkupStepFinishedAnswerAllQuestions => 'Please answer all the questions to continue';
+  String get checkupStepFinishedAnswerAllQuestions =>
+      'Please answer all the questions to continue';
 
   @override
   String get introStepTimeForYourCheckup => 'It\'s time for your checkup.';
 
   @override
-  String get introStepWeWillAskQuestions => 'We will ask you a few questions and have you take your temperature.';
+  String get introStepWeWillAskQuestions =>
+      'We will ask you a few questions and have you take your temperature.';
 
   @override
-  String get introStepAtTheEnd => 'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
+  String get introStepAtTheEnd =>
+      'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
 
   @override
-  String get introStepSwitchLabelContributeData => 'Contribute my data to the COVID-19 response effort.';
+  String get introStepSwitchLabelContributeData =>
+      'Contribute my data to the COVID-19 response effort.';
 
   @override
-  String get introStepSwitchLabelCollectPostalCode => 'We will collect your zip code.';
+  String get introStepSwitchLabelCollectPostalCode =>
+      'We will collect your zip code.';
 
   @override
   String get introStepButtonStartLabel => 'START CHECKUP';
 
   @override
-  String get subjectiveStepQuestionsLoadedError => 'Questions could not be loaded.';
+  String get subjectiveStepQuestionsLoadedError =>
+      'Questions could not be loaded.';
 
   @override
   String get temperatureStepWhenHeading => 'When?';
 
   @override
-  String get temperatureStepWait30Minutes => 'Wait 30 minutes after eating, drinking, or exercising';
+  String get temperatureStepWait30Minutes =>
+      'Wait 30 minutes after eating, drinking, or exercising';
 
   @override
-  String get temperatureStepWait6Hours => 'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
+  String get temperatureStepWait6Hours =>
+      'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
 
   @override
   String get temperatureStepHowHeading => 'How?';
 
   @override
-  String get temperatureStepPleaseEnterValueBelow => 'Please enter a value below 150 ℉';
+  String get temperatureStepPleaseEnterValueBelow =>
+      'Please enter a value below 150 ℉';
 
   @override
-  String get temperatureStepPleaseEnterValueAbove => 'Please enter a value above 70 ℉';
+  String get temperatureStepPleaseEnterValueAbove =>
+      'Please enter a value above 70 ℉';
 
   @override
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
-  String get temperatureStepHowToDialogStep1 => 'Wash your hands using soap and water';
+  String get temperatureStepHowToDialogStep1 =>
+      'Wash your hands using soap and water';
 
   @override
-  String get temperatureStepHowToDialogStep2 => 'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
+  String get temperatureStepHowToDialogStep2 =>
+      'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
 
   @override
-  String get temperatureStepHowToDialogStep3 => 'Put the tip of your thermometer under your tongue and gently close your lips.';
+  String get temperatureStepHowToDialogStep3 =>
+      'Put the tip of your thermometer under your tongue and gently close your lips.';
 
   @override
-  String get temperatureStepHowToDialogStep4 => 'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
+  String get temperatureStepHowToDialogStep4 =>
+      'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
 
   @override
-  String get temperatureStepHowToDialogStep5 => 'Take out your thermometer and record your temperature.';
+  String get temperatureStepHowToDialogStep5 =>
+      'Take out your thermometer and record your temperature.';
 
   @override
   String get temperatureStepHowToDialogReturn => 'RETURN TO CHECKUP';
@@ -158,28 +180,33 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get homeScreenHeading => 'Concerned about your health?';
 
   @override
-  String get homeScreenDoYouHaveSymptoms => 'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
+  String get homeScreenDoYouHaveSymptoms =>
+      'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
 
   @override
   String get homeScreenCheckupButtonLabel => 'START HEALTH CHECKUP';
 
   @override
-  String get homeScreenYouHaveCompletedCheckup => 'You have completed your checkup for today!';
+  String get homeScreenYouHaveCompletedCheckup =>
+      'You have completed your checkup for today!';
 
   @override
-  String get homeScreenCheckBackTomorrow => 'If you continue to experience symptoms, please check back tomorrow.';
+  String get homeScreenCheckBackTomorrow =>
+      'If you continue to experience symptoms, please check back tomorrow.';
 
   @override
   String get homeScreenViewMyAssessment => 'View my assessment';
 
   @override
-  String get shareAppDownloadPrompt => 'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
+  String get shareAppDownloadPrompt =>
+      'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
 
   @override
   String get shareAppProtectYourCommunity => 'Protect Your Community';
 
   @override
-  String get shareAppWithFriendsEtc => 'Share this app with your friends, coworkers, and family (especially grandparents).';
+  String get shareAppWithFriendsEtc =>
+      'Share this app with your friends, coworkers, and family (especially grandparents).';
 
   @override
   String get shareAppNow => 'SHARE NOW';
@@ -194,16 +221,19 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get staySafeLimitContact => 'Limit contact with other people.';
 
   @override
-  String get staySafeCheckBackIf => 'Check back in if you continue to experience symptoms.';
+  String get staySafeCheckBackIf =>
+      'Check back in if you continue to experience symptoms.';
 
   @override
   String get tutorialIntroStepWelcome => 'Welcome to the CovidNearMe App';
 
   @override
-  String get tutorialIntroStepCompleteACheckup => 'Complete a daily health checkup.';
+  String get tutorialIntroStepCompleteACheckup =>
+      'Complete a daily health checkup.';
 
   @override
-  String get tutorialIntroStepReceiveAssessment => 'Receive a personalized health assessment.';
+  String get tutorialIntroStepReceiveAssessment =>
+      'Receive a personalized health assessment.';
 
   @override
   String get tutorialIntroStepAidEffort => 'Aid COVID-19 response efforts.';
@@ -212,7 +242,8 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get tutorialIntroStepLearnMore => 'LEARN MORE';
 
   @override
-  String get getStartedStepJoined => 'You\'ve joined the CovidNearMe community!';
+  String get getStartedStepJoined =>
+      'You\'ve joined the CovidNearMe community!';
 
   @override
   String get consentStepDidNotAgree => 'DID NOT AGREE';
@@ -236,16 +267,20 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get networkUnavailableBannerConnectToWiFi => 'CONNECT TO WIFI';
 
   @override
-  String get networkUnavailableBannerMessage => 'You seem to be offline. Please check your network settings and try again.';
+  String get networkUnavailableBannerMessage =>
+      'You seem to be offline. Please check your network settings and try again.';
 
   @override
-  String get deniedConsentBackButton => 'Go back to the informed consent screen';
+  String get deniedConsentBackButton =>
+      'Go back to the informed consent screen';
 
   @override
-  String get questionShortnessOfBreathTitle => 'Are you experiencing shortness of breath?';
+  String get questionShortnessOfBreathTitle =>
+      'Are you experiencing shortness of breath?';
 
   @override
-  String get questionShortnessOfBreathSubtitle => 'Do you feel like you can\'t get enough air?';
+  String get questionShortnessOfBreathSubtitle =>
+      'Do you feel like you can\'t get enough air?';
 
   @override
   String get questionShortnessOfBreathAnswer0 => 'I can breathe fine';
@@ -257,16 +292,20 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionShortnessOfBreathSemantics0 => 'I can breathe fine';
 
   @override
-  String get questionShortnessOfBreathSemantics1 => 'I have a little trouble breathing';
+  String get questionShortnessOfBreathSemantics1 =>
+      'I have a little trouble breathing';
 
   @override
-  String get questionShortnessOfBreathSemantics2 => 'I have some trouble breathing';
+  String get questionShortnessOfBreathSemantics2 =>
+      'I have some trouble breathing';
 
   @override
-  String get questionShortnessOfBreathSemantics3 => 'It is difficult to breathe';
+  String get questionShortnessOfBreathSemantics3 =>
+      'It is difficult to breathe';
 
   @override
-  String get questionShortnessOfBreathSemantics4 => 'I can hardly breathe at all';
+  String get questionShortnessOfBreathSemantics4 =>
+      'I can hardly breathe at all';
 
   @override
   String get questionHaveACoughTitle => 'Do you have a cough?';
@@ -293,7 +332,8 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveACoughSemantics4 => 'Constantly';
 
   @override
-  String get questionHaveAFeverTitle => 'Have you felt like you\'ve had a fever?';
+  String get questionHaveAFeverTitle =>
+      'Have you felt like you\'ve had a fever?';
 
   @override
   String get questionHaveAFeverAnswer0 => 'No';

--- a/lib/src/ui/screens/checkup/steps/temperature.dart
+++ b/lib/src/ui/screens/checkup/steps/temperature.dart
@@ -108,11 +108,14 @@ class _TemperatureStepState extends State<TemperatureStep> {
         final AppLocalizations localizations = AppLocalizations.of(context);
         final ThemeData theme = Theme.of(context);
         return Scaffold(
-          appBar: AppBar(title: Text(
-            localizations.temperatureStepHowToDialogTitle,
-            style: theme.textTheme.headline.copyWith(color: theme.colorScheme.onBackground),
-            textAlign: TextAlign.center,
-          ),),
+          appBar: AppBar(
+            title: Text(
+              localizations.temperatureStepHowToDialogTitle,
+              style: theme.textTheme.headline
+                  .copyWith(color: theme.colorScheme.onBackground),
+              textAlign: TextAlign.center,
+            ),
+          ),
           body: ScrollMoreIndicator(
             controller: controller,
             child: ListView(

--- a/lib/src/ui/screens/checkup/steps/temperature.dart
+++ b/lib/src/ui/screens/checkup/steps/temperature.dart
@@ -133,7 +133,7 @@ class _TemperatureStepState extends State<TemperatureStep> {
                   number: 2,
                 ),
                 Text(
-                  'How?',
+                  localizations.temperatureStepHowHeading,
                   style: categoryFontStyle,
                 ),
                 SizedBox(height: 10),

--- a/lib/src/ui/screens/tutorial/steps/consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/consent.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
@@ -9,7 +8,6 @@ import 'package:provider/provider.dart';
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:covidnearme/src/ui/router.dart';
-import 'package:covidnearme/src/ui/widgets/loading_indicator.dart';
 
 class ConsentStep extends StatelessWidget {
   void _handleResponse(
@@ -48,112 +46,103 @@ class ConsentStep extends StatelessWidget {
             !state.preferences.agreedToTerms;
 
         return SafeArea(
-          child: FutureBuilder(
-            future: rootBundle.loadString('assets/copy/consent.md'),
-            builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
-              if (snapshot.hasData) {
-                return Stack(
-                  children: <Widget>[
-                    Markdown(
-                      padding: EdgeInsets.fromLTRB(20, 40, 20, 150),
-                      data: snapshot.data,
-                      styleSheet:
-                          MarkdownStyleSheet.fromTheme(Theme.of(context))
-                              .copyWith(
-                        blockSpacing: 20,
-                        h1Align: WrapAlignment.center,
-                        p: Theme.of(context).textTheme.body2.copyWith(
-                              color: Theme.of(context).colorScheme.onSurface,
+          child: Stack(
+            children: <Widget>[
+              Markdown(
+                padding: EdgeInsets.fromLTRB(20, 40, 20, 150),
+                data: localizations.consentStepQuestion,
+                styleSheet:
+                    MarkdownStyleSheet.fromTheme(Theme.of(context))
+                        .copyWith(
+                  blockSpacing: 20,
+                  h1Align: WrapAlignment.center,
+                  p: Theme.of(context).textTheme.body2.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                  textScaleFactor: MediaQuery.of(context).textScaleFactor,
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.bottomCenter,
+                      end: Alignment.topCenter,
+                      colors: <Color>[
+                        Theme.of(context).colorScheme.surface,
+                        Theme.of(context)
+                            .colorScheme
+                            .surface
+                            .withOpacity(0.5),
+                        Theme.of(context)
+                            .colorScheme
+                            .surface
+                            .withOpacity(0),
+                      ],
+                      stops: <double>[0, 0.8, 1.0],
+                    ),
+                  ),
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(20, 40, 20, 20),
+                    child: Wrap(
+                      alignment: WrapAlignment.start,
+                      spacing: 20.0,
+                      runSpacing: 20.0,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: <Widget>[
+                        ConstrainedBox(
+                          constraints: BoxConstraints(minHeight: 60),
+                          child: RaisedButton(
+                            onPressed: () => _handleResponse(
+                              context: context,
+                              state: state,
+                              response: false,
                             ),
-                        textScaleFactor: MediaQuery.of(context).textScaleFactor,
-                      ),
-                    ),
-                    Align(
-                      alignment: Alignment.bottomCenter,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.bottomCenter,
-                            end: Alignment.topCenter,
-                            colors: <Color>[
-                              Theme.of(context).colorScheme.surface,
-                              Theme.of(context)
-                                  .colorScheme
-                                  .surface
-                                  .withOpacity(0.5),
-                              Theme.of(context)
-                                  .colorScheme
-                                  .surface
-                                  .withOpacity(0),
-                            ],
-                            stops: <double>[0, 0.8, 1.0],
+                            child: rejected
+                                ? Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: <Widget>[
+                                      Icon(
+                                        Icons.close,
+                                        color: Colors.red,
+                                      ),
+                                      Text(localizations
+                                          .consentStepDidNotAgree),
+                                    ],
+                                  )
+                                : Text(localizations.consentStepNo),
                           ),
                         ),
-                        child: Padding(
-                          padding: EdgeInsets.fromLTRB(20, 40, 20, 20),
-                          child: Wrap(
-                            alignment: WrapAlignment.start,
-                            spacing: 20.0,
-                            runSpacing: 20.0,
-                            crossAxisAlignment: WrapCrossAlignment.center,
-                            children: <Widget>[
-                              ConstrainedBox(
-                                constraints: BoxConstraints(minHeight: 60),
-                                child: RaisedButton(
-                                  onPressed: () => _handleResponse(
-                                    context: context,
-                                    state: state,
-                                    response: false,
-                                  ),
-                                  child: rejected
-                                      ? Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: <Widget>[
-                                            Icon(
-                                              Icons.close,
-                                              color: Colors.red,
-                                            ),
-                                            Text(localizations
-                                                .consentStepDidNotAgree),
-                                          ],
-                                        )
-                                      : Text(localizations.consentStepNo),
-                                ),
-                              ),
-                              ConstrainedBox(
-                                constraints: BoxConstraints(minHeight: 60),
-                                child: RaisedButton(
-                                  onPressed: () => _handleResponse(
-                                    context: context,
-                                    state: state,
-                                    response: true,
-                                  ),
-                                  child: agreed
-                                      ? Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: <Widget>[
-                                            Icon(
-                                              Icons.check,
-                                              color: Colors.green,
-                                            ),
-                                            Text(localizations
-                                                .consentStepAgreed),
-                                          ],
-                                        )
-                                      : Text(localizations.consentStepIAgree),
-                                ),
-                              ),
-                            ],
+                        ConstrainedBox(
+                          constraints: BoxConstraints(minHeight: 60),
+                          child: RaisedButton(
+                            onPressed: () => _handleResponse(
+                              context: context,
+                              state: state,
+                              response: true,
+                            ),
+                            child: agreed
+                                ? Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: <Widget>[
+                                      Icon(
+                                        Icons.check,
+                                        color: Colors.green,
+                                      ),
+                                      Text(localizations
+                                          .consentStepAgreed),
+                                    ],
+                                  )
+                                : Text(localizations.consentStepIAgree),
                           ),
                         ),
-                      ),
+                      ],
                     ),
-                  ],
-                );
-              } else {
-                return LoadingIndicator(localizations.consentStepLoading);
-              }
-            },
+                  ),
+                ),
+              ),
+            ],
           ),
         );
       },

--- a/lib/src/ui/screens/tutorial/steps/consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/consent.dart
@@ -52,8 +52,7 @@ class ConsentStep extends StatelessWidget {
                 padding: EdgeInsets.fromLTRB(20, 40, 20, 150),
                 data: localizations.consentStepQuestion,
                 styleSheet:
-                    MarkdownStyleSheet.fromTheme(Theme.of(context))
-                        .copyWith(
+                    MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
                   blockSpacing: 20,
                   h1Align: WrapAlignment.center,
                   p: Theme.of(context).textTheme.body2.copyWith(
@@ -71,14 +70,8 @@ class ConsentStep extends StatelessWidget {
                       end: Alignment.topCenter,
                       colors: <Color>[
                         Theme.of(context).colorScheme.surface,
-                        Theme.of(context)
-                            .colorScheme
-                            .surface
-                            .withOpacity(0.5),
-                        Theme.of(context)
-                            .colorScheme
-                            .surface
-                            .withOpacity(0),
+                        Theme.of(context).colorScheme.surface.withOpacity(0.5),
+                        Theme.of(context).colorScheme.surface.withOpacity(0),
                       ],
                       stops: <double>[0, 0.8, 1.0],
                     ),
@@ -107,8 +100,8 @@ class ConsentStep extends StatelessWidget {
                                         Icons.close,
                                         color: Colors.red,
                                       ),
-                                      Text(localizations
-                                          .consentStepDidNotAgree),
+                                      Text(
+                                          localizations.consentStepDidNotAgree),
                                     ],
                                   )
                                 : Text(localizations.consentStepNo),
@@ -130,8 +123,7 @@ class ConsentStep extends StatelessWidget {
                                         Icons.check,
                                         color: Colors.green,
                                       ),
-                                      Text(localizations
-                                          .consentStepAgreed),
+                                      Text(localizations.consentStepAgreed),
                                     ],
                                   )
                                 : Text(localizations.consentStepIAgree),

--- a/lib/src/ui/screens/tutorial/steps/denied_consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/denied_consent.dart
@@ -64,11 +64,9 @@ class DeniedConsent extends StatelessWidget {
                               .copyWith(
                         h1Align: WrapAlignment.center,
                         p: Theme.of(context).textTheme.body2.copyWith(
-                              color:
-                                  Theme.of(context).colorScheme.onSurface,
+                              color: Theme.of(context).colorScheme.onSurface,
                             ),
-                        textScaleFactor:
-                            MediaQuery.of(context).textScaleFactor,
+                        textScaleFactor: MediaQuery.of(context).textScaleFactor,
                       ),
                     ),
                   ),

--- a/lib/src/ui/screens/tutorial/steps/denied_consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/denied_consent.dart
@@ -2,13 +2,11 @@ import 'dart:ui';
 
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
 
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
-import 'package:covidnearme/src/ui/widgets/loading_indicator.dart';
 
 class DeniedConsent extends StatelessWidget {
   @override
@@ -28,64 +26,55 @@ class DeniedConsent extends StatelessWidget {
             curve: Curves.easeInOut,
           ),
         ),
-        title: Text('Your Health Checkup'),
+        title: Text(localizations.checkupScreenTitle),
       ),
       body: BlocBuilder<PreferencesBloc, PreferencesState>(
         builder: (context, state) {
           return SafeArea(
-            child: FutureBuilder(
-              future: rootBundle.loadString('assets/copy/denied_consent.md'),
-              builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
-                if (snapshot.hasData) {
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: <Widget>[
-                      Padding(
-                        padding: EdgeInsets.only(top: 48, bottom: 24),
-                        child: Icon(
-                          Icons.report_problem,
-                          size: 100,
-                        ),
-                      ),
-                      Text(
-                        'Consent denied',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Theme.of(context).primaryColor,
-                          fontSize: 20,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      Flexible(
-                        child: Padding(
-                          padding: EdgeInsets.symmetric(
-                            horizontal: 8,
-                          ),
-                          child: Markdown(
-                            physics: NeverScrollableScrollPhysics(),
-                            padding: EdgeInsets.fromLTRB(20, 40, 20, 150),
-                            data: snapshot.data,
-                            styleSheet:
-                                MarkdownStyleSheet.fromTheme(Theme.of(context))
-                                    .copyWith(
-                              h1Align: WrapAlignment.center,
-                              p: Theme.of(context).textTheme.body2.copyWith(
-                                    color:
-                                        Theme.of(context).colorScheme.onSurface,
-                                  ),
-                              textScaleFactor:
-                                  MediaQuery.of(context).textScaleFactor,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: EdgeInsets.only(top: 48, bottom: 24),
+                  child: Icon(
+                    Icons.report_problem,
+                    size: 100,
+                  ),
+                ),
+                Text(
+                  localizations.deniedConsentHeading,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Theme.of(context).primaryColor,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Flexible(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 8,
+                    ),
+                    child: Markdown(
+                      physics: NeverScrollableScrollPhysics(),
+                      padding: EdgeInsets.fromLTRB(20, 40, 20, 150),
+                      data: localizations.deniedConsentMessage,
+                      styleSheet:
+                          MarkdownStyleSheet.fromTheme(Theme.of(context))
+                              .copyWith(
+                        h1Align: WrapAlignment.center,
+                        p: Theme.of(context).textTheme.body2.copyWith(
+                              color:
+                                  Theme.of(context).colorScheme.onSurface,
                             ),
-                          ),
-                        ),
+                        textScaleFactor:
+                            MediaQuery.of(context).textScaleFactor,
                       ),
-                      Text('Consent denied'),
-                    ],
-                  );
-                } else {
-                  return LoadingIndicator('Loading...');
-                }
-              },
+                    ),
+                  ),
+                ),
+                Text(localizations.deniedConsentHeading),
+              ],
             ),
           );
         },

--- a/lib/src/ui/widgets/scroll_more_indicator.dart
+++ b/lib/src/ui/widgets/scroll_more_indicator.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+
 import 'bob.dart';
 
 class ScrollMoreIndicator extends StatefulWidget {
@@ -86,6 +88,7 @@ class _ScrollMoreIndicatorState extends State<ScrollMoreIndicator> {
     final Color textColor = DefaultTextStyle.of(context).style.color;
     final Color backColor = Theme.of(context).scaffoldBackgroundColor;
     final double iconSize = 48.0 * MediaQuery.of(context).textScaleFactor;
+    final AppLocalizations localizations = AppLocalizations.of(context);
     return Stack(
       fit: StackFit.passthrough,
       children: <Widget>[
@@ -138,7 +141,7 @@ class _ScrollMoreIndicatorState extends State<ScrollMoreIndicator> {
                           children: <Widget>[
                             Padding(
                               padding: EdgeInsets.only(bottom: iconSize / 2.0),
-                              child: Text('SCROLL FOR MORE',
+                              child: Text(localizations.scrollMoreIndicatorMessage,
                                   style: Theme.of(context)
                                       .textTheme
                                       .button

--- a/lib/src/ui/widgets/scroll_more_indicator.dart
+++ b/lib/src/ui/widgets/scroll_more_indicator.dart
@@ -141,7 +141,8 @@ class _ScrollMoreIndicatorState extends State<ScrollMoreIndicator> {
                           children: <Widget>[
                             Padding(
                               padding: EdgeInsets.only(bottom: iconSize / 2.0),
-                              child: Text(localizations.scrollMoreIndicatorMessage,
+                              child: Text(
+                                  localizations.scrollMoreIndicatorMessage,
                                   style: Theme.of(context)
                                       .textTheme
                                       .button

--- a/test/ui/screens/tutorial_test.dart
+++ b/test/ui/screens/tutorial_test.dart
@@ -28,12 +28,6 @@ void main() {
     await tester.pumpWidget(Container());
     await tester.pumpWidget(setUpTutorialScreen(child: ConsentStep()));
 
-    // Loading screen.
-    expect(find.text('Loading...'), findsOneWidget);
-
-    // Finish loading transition.
-    await tester.pumpAndSettle();
-
     expect(find.text('NO'), findsOneWidget);
     expect(find.text('I AGREE'), findsOneWidget);
 

--- a/tools/localizations_utils.dart
+++ b/tools/localizations_utils.dart
@@ -446,7 +446,9 @@ String generateString(String value, {bool escapeDollar = true}) {
       .replaceAll('"', '\\"')
       .replaceAll(backslash, '\\\\');
 
-  return "'$value'";
+  // At this point "\n" - backslash followed by newline - will have been converted to
+  // a newline character, which can only appear in a triple-quoted string.
+  return value.contains('\n') ? "'''$value'''" : "'$value'";
 }
 
 /// Only used to generate localization strings for the Kannada locale ('kn') because


### PR DESCRIPTION
Added all of the remaining user-facing strings to the lib/src/l10n/app_en.arb, including the messages which had been stored in the consent markdown  files.  The consent screen no longer requires an async load or a refresh indicator. 