### PR TITLE
Convert Temperature entry page to automatically detect fahrenheit vs celsius

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -166,6 +166,11 @@
     "description": "Title for a dialog that explains how to take your temperature in 5 steps"
   },
 
+  "temperatureStepTemperatureOutOfRangeError": "Please enter a valid temperature value.",
+  "@temperatureStepTemperatureOutOfRangeError": {
+    "description": "Error that is displayed if the temperature entered is not in a valid temperature range."
+  },
+
   "temperatureStepHowToDialogStep1": "Wash your hands using soap and water",
   "@temperatureStepHowToDialogStep1": {
     "description": "Step 1 in the dialog that explains how to take your temperature in 5 steps"

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -191,6 +191,9 @@ abstract class AppLocalizations {
   // Title for a dialog that explains how to take your temperature in 5 steps
   String get temperatureStepHowToDialogTitle;
 
+  // Error that is displayed if the temperature entered is not in a valid temperature range.
+  String get temperatureStepTemperatureOutOfRangeError;
+
   // Step 1 in the dialog that explains how to take your temperature in 5 steps
   String get temperatureStepHowToDialogStep1;
 

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -145,6 +145,10 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
+  String get temperatureStepTemperatureOutOfRangeError =>
+      'Please enter a valid temperature value.';
+
+  @override
   String get temperatureStepHowToDialogStep1 =>
       'Wash your hands using soap and water';
 

--- a/lib/src/ui/screens/tutorial/tutorial.dart
+++ b/lib/src/ui/screens/tutorial/tutorial.dart
@@ -44,7 +44,8 @@ class _TutorialScreenState extends State<TutorialScreen> {
                   children: <Widget>[
                     IntroStep(),
                     ConsentStep(),
-                    if (state.preferences.agreedToTerms == false) DeniedConsent(),
+                    if (state.preferences.agreedToTerms == false)
+                      DeniedConsent(),
                   ],
                 ),
               ),


### PR DESCRIPTION
Converts the temperature input page to autodetect whether the entered number is celsius vs fahrenheit, and show the appropriate units.

Fixes #106

Looks like this: 
![Screenshot_1585507792](https://user-images.githubusercontent.com/8867023/77857731-3a09e380-71b4-11ea-9134-4a0696c59db0.png)

![Screenshot_1585507798](https://user-images.githubusercontent.com/8867023/77857737-3fffc480-71b4-11ea-81cb-d0db21cab33c.png)

![Screenshot_1585507804](https://user-images.githubusercontent.com/8867023/77857739-44c47880-71b4-11ea-82a6-8062767839a7.png)

![Screenshot_1585507819](https://user-images.githubusercontent.com/8867023/77857742-47bf6900-71b4-11ea-8863-e0b59da43d73.png)
