### PR TITLE
Converts the country input field into a searchable dropdown menu.

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -595,6 +595,16 @@
     "description": "Menu item displayed with no country is yet selected."
   },
 
+  "locationStepCountrySearchPrompt": "Please select the country where you are located",
+  "@locationStepCountrySearchPrompt": {
+    "description": "Menu item displayed with no country is yet selected."
+  },
+
+  "locationStepCountryButtonLabel": "Country:",
+  "@locationStepCountryButtonLabel": {
+    "description": "Label for the dropdown button that selects a country."
+  },
+
   "countryCodeAD": "Andorra",
   "@countryCodeAD": {
     "description": "Name of the country 'Andorra'."

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -588,5 +588,1256 @@
   "scrollMoreIndicatorMessage": "SCROLL FOR MORE",
   "@scrollMoreIndicatorMessage": {
     "description": "Let the user that they can scroll to see more content"
+  },
+
+  "locationStepNoCountrySelected": "None selected",
+  "@locationStepNoCountrySelected": {
+    "description": "Menu item displayed with no country is yet selected."
+  },
+
+  "countryCodeAD": "Andorra",
+  "@countryCodeAD": {
+    "description": "Name of the country 'Andorra'."
+  },
+
+  "countryCodeAE": "United Arab Emirates",
+  "@countryCodeAE": {
+    "description": "Name of the country 'United Arab Emirates'."
+  },
+
+  "countryCodeAF": "Afghanistan",
+  "@countryCodeAF": {
+    "description": "Name of the country 'Afghanistan'."
+  },
+
+  "countryCodeAG": "Antigua and Barbuda",
+  "@countryCodeAG": {
+    "description": "Name of the country 'Antigua and Barbuda'."
+  },
+
+  "countryCodeAI": "Anguilla",
+  "@countryCodeAI": {
+    "description": "Name of the country 'Anguilla'."
+  },
+
+  "countryCodeAL": "Albania",
+  "@countryCodeAL": {
+    "description": "Name of the country 'Albania'."
+  },
+
+  "countryCodeAM": "Armenia",
+  "@countryCodeAM": {
+    "description": "Name of the country 'Armenia'."
+  },
+
+  "countryCodeAO": "Angola",
+  "@countryCodeAO": {
+    "description": "Name of the country 'Angola'."
+  },
+
+  "countryCodeAQ": "Antarctica",
+  "@countryCodeAQ": {
+    "description": "Name of the country 'Antarctica'."
+  },
+
+  "countryCodeAR": "Argentina",
+  "@countryCodeAR": {
+    "description": "Name of the country 'Argentina'."
+  },
+
+  "countryCodeAS": "American Samoa",
+  "@countryCodeAS": {
+    "description": "Name of the country 'American Samoa'."
+  },
+
+  "countryCodeAT": "Austria",
+  "@countryCodeAT": {
+    "description": "Name of the country 'Austria'."
+  },
+
+  "countryCodeAU": "Australia",
+  "@countryCodeAU": {
+    "description": "Name of the country 'Australia'."
+  },
+
+  "countryCodeAW": "Aruba",
+  "@countryCodeAW": {
+    "description": "Name of the country 'Aruba'."
+  },
+
+  "countryCodeAX": "Åland Islands",
+  "@countryCodeAX": {
+    "description": "Name of the country 'Åland Islands'."
+  },
+
+  "countryCodeAZ": "Azerbaijan",
+  "@countryCodeAZ": {
+    "description": "Name of the country 'Azerbaijan'."
+  },
+
+  "countryCodeBA": "Bosnia and Herzegovina",
+  "@countryCodeBA": {
+    "description": "Name of the country 'Bosnia and Herzegovina'."
+  },
+
+  "countryCodeBB": "Barbados",
+  "@countryCodeBB": {
+    "description": "Name of the country 'Barbados'."
+  },
+
+  "countryCodeBD": "Bangladesh",
+  "@countryCodeBD": {
+    "description": "Name of the country 'Bangladesh'."
+  },
+
+  "countryCodeBE": "Belgium",
+  "@countryCodeBE": {
+    "description": "Name of the country 'Belgium'."
+  },
+
+  "countryCodeBF": "Burkina Faso",
+  "@countryCodeBF": {
+    "description": "Name of the country 'Burkina Faso'."
+  },
+
+  "countryCodeBG": "Bulgaria",
+  "@countryCodeBG": {
+    "description": "Name of the country 'Bulgaria'."
+  },
+
+  "countryCodeBH": "Bahrain",
+  "@countryCodeBH": {
+    "description": "Name of the country 'Bahrain'."
+  },
+
+  "countryCodeBI": "Burundi",
+  "@countryCodeBI": {
+    "description": "Name of the country 'Burundi'."
+  },
+
+  "countryCodeBJ": "Benin",
+  "@countryCodeBJ": {
+    "description": "Name of the country 'Benin'."
+  },
+
+  "countryCodeBL": "Saint Barthélemy",
+  "@countryCodeBL": {
+    "description": "Name of the country 'Saint Barthélemy'."
+  },
+
+  "countryCodeBM": "Bermuda",
+  "@countryCodeBM": {
+    "description": "Name of the country 'Bermuda'."
+  },
+
+  "countryCodeBN": "Brunei Darussalam",
+  "@countryCodeBN": {
+    "description": "Name of the country 'Brunei Darussalam'."
+  },
+
+  "countryCodeBO": "Bolivia (Plurinational State of)",
+  "@countryCodeBO": {
+    "description": "Name of the country 'Bolivia (Plurinational State of)'."
+  },
+
+  "countryCodeBQ": "Bonaire, Sint Eustatius and Saba",
+  "@countryCodeBQ": {
+    "description": "Name of the country 'Bonaire, Sint Eustatius and Saba'."
+  },
+
+  "countryCodeBR": "Brazil",
+  "@countryCodeBR": {
+    "description": "Name of the country 'Brazil'."
+  },
+
+  "countryCodeBS": "Bahamas",
+  "@countryCodeBS": {
+    "description": "Name of the country 'Bahamas'."
+  },
+
+  "countryCodeBT": "Bhutan",
+  "@countryCodeBT": {
+    "description": "Name of the country 'Bhutan'."
+  },
+
+  "countryCodeBV": "Bouvet Island",
+  "@countryCodeBV": {
+    "description": "Name of the country 'Bouvet Island'."
+  },
+
+  "countryCodeBW": "Botswana",
+  "@countryCodeBW": {
+    "description": "Name of the country 'Botswana'."
+  },
+
+  "countryCodeBY": "Belarus",
+  "@countryCodeBY": {
+    "description": "Name of the country 'Belarus'."
+  },
+
+  "countryCodeBZ": "Belize",
+  "@countryCodeBZ": {
+    "description": "Name of the country 'Belize'."
+  },
+
+  "countryCodeCA": "Canada",
+  "@countryCodeCA": {
+    "description": "Name of the country 'Canada'."
+  },
+
+  "countryCodeCC": "Cocos (Keeling) Islands",
+  "@countryCodeCC": {
+    "description": "Name of the country 'Cocos (Keeling) Islands'."
+  },
+
+  "countryCodeCD": "Congo, Democratic Republic of the",
+  "@countryCodeCD": {
+    "description": "Name of the country 'Congo, Democratic Republic of the'."
+  },
+
+  "countryCodeCF": "Central African Republic",
+  "@countryCodeCF": {
+    "description": "Name of the country 'Central African Republic'."
+  },
+
+  "countryCodeCG": "Congo",
+  "@countryCodeCG": {
+    "description": "Name of the country 'Congo'."
+  },
+
+  "countryCodeCH": "Switzerland",
+  "@countryCodeCH": {
+    "description": "Name of the country 'Switzerland'."
+  },
+
+  "countryCodeCI": "Côte d'Ivoire",
+  "@countryCodeCI": {
+    "description": "Name of the country 'Côte d'Ivoire'."
+  },
+
+  "countryCodeCK": "Cook Islands",
+  "@countryCodeCK": {
+    "description": "Name of the country 'Cook Islands'."
+  },
+
+  "countryCodeCL": "Chile",
+  "@countryCodeCL": {
+    "description": "Name of the country 'Chile'."
+  },
+
+  "countryCodeCM": "Cameroon",
+  "@countryCodeCM": {
+    "description": "Name of the country 'Cameroon'."
+  },
+
+  "countryCodeCN": "China",
+  "@countryCodeCN": {
+    "description": "Name of the country 'China'."
+  },
+
+  "countryCodeCO": "Colombia",
+  "@countryCodeCO": {
+    "description": "Name of the country 'Colombia'."
+  },
+
+  "countryCodeCR": "Costa Rica",
+  "@countryCodeCR": {
+    "description": "Name of the country 'Costa Rica'."
+  },
+
+  "countryCodeCU": "Cuba",
+  "@countryCodeCU": {
+    "description": "Name of the country 'Cuba'."
+  },
+
+  "countryCodeCV": "Cabo Verde",
+  "@countryCodeCV": {
+    "description": "Name of the country 'Cabo Verde'."
+  },
+
+  "countryCodeCW": "Curaçao",
+  "@countryCodeCW": {
+    "description": "Name of the country 'Curaçao'."
+  },
+
+  "countryCodeCX": "Christmas Island",
+  "@countryCodeCX": {
+    "description": "Name of the country 'Christmas Island'."
+  },
+
+  "countryCodeCY": "Cyprus",
+  "@countryCodeCY": {
+    "description": "Name of the country 'Cyprus'."
+  },
+
+  "countryCodeCZ": "Czechia",
+  "@countryCodeCZ": {
+    "description": "Name of the country 'Czechia'."
+  },
+
+  "countryCodeDE": "Germany",
+  "@countryCodeDE": {
+    "description": "Name of the country 'Germany'."
+  },
+
+  "countryCodeDJ": "Djibouti",
+  "@countryCodeDJ": {
+    "description": "Name of the country 'Djibouti'."
+  },
+
+  "countryCodeDK": "Denmark",
+  "@countryCodeDK": {
+    "description": "Name of the country 'Denmark'."
+  },
+
+  "countryCodeDM": "Dominica",
+  "@countryCodeDM": {
+    "description": "Name of the country 'Dominica'."
+  },
+
+  "countryCodeDO": "Dominican Republic",
+  "@countryCodeDO": {
+    "description": "Name of the country 'Dominican Republic'."
+  },
+
+  "countryCodeDZ": "Algeria",
+  "@countryCodeDZ": {
+    "description": "Name of the country 'Algeria'."
+  },
+
+  "countryCodeEC": "Ecuador",
+  "@countryCodeEC": {
+    "description": "Name of the country 'Ecuador'."
+  },
+
+  "countryCodeEE": "Estonia",
+  "@countryCodeEE": {
+    "description": "Name of the country 'Estonia'."
+  },
+
+  "countryCodeEG": "Egypt",
+  "@countryCodeEG": {
+    "description": "Name of the country 'Egypt'."
+  },
+
+  "countryCodeEH": "Western Sahara",
+  "@countryCodeEH": {
+    "description": "Name of the country 'Western Sahara'."
+  },
+
+  "countryCodeER": "Eritrea",
+  "@countryCodeER": {
+    "description": "Name of the country 'Eritrea'."
+  },
+
+  "countryCodeES": "Spain",
+  "@countryCodeES": {
+    "description": "Name of the country 'Spain'."
+  },
+
+  "countryCodeET": "Ethiopia",
+  "@countryCodeET": {
+    "description": "Name of the country 'Ethiopia'."
+  },
+
+  "countryCodeFI": "Finland",
+  "@countryCodeFI": {
+    "description": "Name of the country 'Finland'."
+  },
+
+  "countryCodeFJ": "Fiji",
+  "@countryCodeFJ": {
+    "description": "Name of the country 'Fiji'."
+  },
+
+  "countryCodeFK": "Falkland Islands (Malvinas)",
+  "@countryCodeFK": {
+    "description": "Name of the country 'Falkland Islands (Malvinas)'."
+  },
+
+  "countryCodeFM": "Micronesia (Federated States of)",
+  "@countryCodeFM": {
+    "description": "Name of the country 'Micronesia (Federated States of)'."
+  },
+
+  "countryCodeFO": "Faroe Islands",
+  "@countryCodeFO": {
+    "description": "Name of the country 'Faroe Islands'."
+  },
+
+  "countryCodeFR": "France",
+  "@countryCodeFR": {
+    "description": "Name of the country 'France'."
+  },
+
+  "countryCodeGA": "Gabon",
+  "@countryCodeGA": {
+    "description": "Name of the country 'Gabon'."
+  },
+
+  "countryCodeGB": "United Kingdom",
+  "@countryCodeGB": {
+    "description": "Name of the country 'United Kingdom'."
+  },
+
+  "countryCodeGD": "Grenada",
+  "@countryCodeGD": {
+    "description": "Name of the country 'Grenada'."
+  },
+
+  "countryCodeGE": "Georgia",
+  "@countryCodeGE": {
+    "description": "Name of the country 'Georgia'."
+  },
+
+  "countryCodeGF": "French Guiana",
+  "@countryCodeGF": {
+    "description": "Name of the country 'French Guiana'."
+  },
+
+  "countryCodeGG": "Guernsey",
+  "@countryCodeGG": {
+    "description": "Name of the country 'Guernsey'."
+  },
+
+  "countryCodeGH": "Ghana",
+  "@countryCodeGH": {
+    "description": "Name of the country 'Ghana'."
+  },
+
+  "countryCodeGI": "Gibraltar",
+  "@countryCodeGI": {
+    "description": "Name of the country 'Gibraltar'."
+  },
+
+  "countryCodeGL": "Greenland",
+  "@countryCodeGL": {
+    "description": "Name of the country 'Greenland'."
+  },
+
+  "countryCodeGM": "Gambia",
+  "@countryCodeGM": {
+    "description": "Name of the country 'Gambia'."
+  },
+
+  "countryCodeGN": "Guinea",
+  "@countryCodeGN": {
+    "description": "Name of the country 'Guinea'."
+  },
+
+  "countryCodeGP": "Guadeloupe",
+  "@countryCodeGP": {
+    "description": "Name of the country 'Guadeloupe'."
+  },
+
+  "countryCodeGQ": "Equatorial Guinea",
+  "@countryCodeGQ": {
+    "description": "Name of the country 'Equatorial Guinea'."
+  },
+
+  "countryCodeGR": "Greece",
+  "@countryCodeGR": {
+    "description": "Name of the country 'Greece'."
+  },
+
+  "countryCodeGS": "South Georgia and the South Sandwich Islands",
+  "@countryCodeGS": {
+    "description": "Name of the country 'South Georgia and the South Sandwich Islands'."
+  },
+
+  "countryCodeGT": "Guatemala",
+  "@countryCodeGT": {
+    "description": "Name of the country 'Guatemala'."
+  },
+
+  "countryCodeGU": "Guam",
+  "@countryCodeGU": {
+    "description": "Name of the country 'Guam'."
+  },
+
+  "countryCodeGW": "Guinea-Bissau",
+  "@countryCodeGW": {
+    "description": "Name of the country 'Guinea-Bissau'."
+  },
+
+  "countryCodeGY": "Guyana",
+  "@countryCodeGY": {
+    "description": "Name of the country 'Guyana'."
+  },
+
+  "countryCodeHK": "Hong Kong",
+  "@countryCodeHK": {
+    "description": "Name of the country 'Hong Kong'."
+  },
+
+  "countryCodeHM": "Heard Island and McDonald Islands",
+  "@countryCodeHM": {
+    "description": "Name of the country 'Heard Island and McDonald Islands'."
+  },
+
+  "countryCodeHN": "Honduras",
+  "@countryCodeHN": {
+    "description": "Name of the country 'Honduras'."
+  },
+
+  "countryCodeHR": "Croatia",
+  "@countryCodeHR": {
+    "description": "Name of the country 'Croatia'."
+  },
+
+  "countryCodeHT": "Haiti",
+  "@countryCodeHT": {
+    "description": "Name of the country 'Haiti'."
+  },
+
+  "countryCodeHU": "Hungary",
+  "@countryCodeHU": {
+    "description": "Name of the country 'Hungary'."
+  },
+
+  "countryCodeID": "Indonesia",
+  "@countryCodeID": {
+    "description": "Name of the country 'Indonesia'."
+  },
+
+  "countryCodeIE": "Ireland",
+  "@countryCodeIE": {
+    "description": "Name of the country 'Ireland'."
+  },
+
+  "countryCodeIL": "Israel",
+  "@countryCodeIL": {
+    "description": "Name of the country 'Israel'."
+  },
+
+  "countryCodeIM": "Isle of Man",
+  "@countryCodeIM": {
+    "description": "Name of the country 'Isle of Man'."
+  },
+
+  "countryCodeIN": "India",
+  "@countryCodeIN": {
+    "description": "Name of the country 'India'."
+  },
+
+  "countryCodeIO": "British Indian Ocean Territory",
+  "@countryCodeIO": {
+    "description": "Name of the country 'British Indian Ocean Territory'."
+  },
+
+  "countryCodeIQ": "Iraq",
+  "@countryCodeIQ": {
+    "description": "Name of the country 'Iraq'."
+  },
+
+  "countryCodeIR": "Iran (Islamic Republic of)",
+  "@countryCodeIR": {
+    "description": "Name of the country 'Iran (Islamic Republic of)'."
+  },
+
+  "countryCodeIS": "Iceland",
+  "@countryCodeIS": {
+    "description": "Name of the country 'Iceland'."
+  },
+
+  "countryCodeIT": "Italy",
+  "@countryCodeIT": {
+    "description": "Name of the country 'Italy'."
+  },
+
+  "countryCodeJE": "Jersey",
+  "@countryCodeJE": {
+    "description": "Name of the country 'Jersey'."
+  },
+
+  "countryCodeJM": "Jamaica",
+  "@countryCodeJM": {
+    "description": "Name of the country 'Jamaica'."
+  },
+
+  "countryCodeJO": "Jordan",
+  "@countryCodeJO": {
+    "description": "Name of the country 'Jordan'."
+  },
+
+  "countryCodeJP": "Japan",
+  "@countryCodeJP": {
+    "description": "Name of the country 'Japan'."
+  },
+
+  "countryCodeKE": "Kenya",
+  "@countryCodeKE": {
+    "description": "Name of the country 'Kenya'."
+  },
+
+  "countryCodeKG": "Kyrgyzstan",
+  "@countryCodeKG": {
+    "description": "Name of the country 'Kyrgyzstan'."
+  },
+
+  "countryCodeKH": "Cambodia",
+  "@countryCodeKH": {
+    "description": "Name of the country 'Cambodia'."
+  },
+
+  "countryCodeKI": "Kiribati",
+  "@countryCodeKI": {
+    "description": "Name of the country 'Kiribati'."
+  },
+
+  "countryCodeKM": "Comoros",
+  "@countryCodeKM": {
+    "description": "Name of the country 'Comoros'."
+  },
+
+  "countryCodeKN": "Saint Kitts and Nevis",
+  "@countryCodeKN": {
+    "description": "Name of the country 'Saint Kitts and Nevis'."
+  },
+
+  "countryCodeKP": "Korea (Democratic People's Republic of)",
+  "@countryCodeKP": {
+    "description": "Name of the country 'Korea (Democratic People's Republic of)'."
+  },
+
+  "countryCodeKR": "Korea, Republic of",
+  "@countryCodeKR": {
+    "description": "Name of the country 'Korea, Republic of'."
+  },
+
+  "countryCodeKW": "Kuwait",
+  "@countryCodeKW": {
+    "description": "Name of the country 'Kuwait'."
+  },
+
+  "countryCodeKY": "Cayman Islands",
+  "@countryCodeKY": {
+    "description": "Name of the country 'Cayman Islands'."
+  },
+
+  "countryCodeKZ": "Kazakhstan",
+  "@countryCodeKZ": {
+    "description": "Name of the country 'Kazakhstan'."
+  },
+
+  "countryCodeLA": "Lao People's Democratic Republic",
+  "@countryCodeLA": {
+    "description": "Name of the country 'Lao People's Democratic Republic'."
+  },
+
+  "countryCodeLB": "Lebanon",
+  "@countryCodeLB": {
+    "description": "Name of the country 'Lebanon'."
+  },
+
+  "countryCodeLC": "Saint Lucia",
+  "@countryCodeLC": {
+    "description": "Name of the country 'Saint Lucia'."
+  },
+
+  "countryCodeLI": "Liechtenstein",
+  "@countryCodeLI": {
+    "description": "Name of the country 'Liechtenstein'."
+  },
+
+  "countryCodeLK": "Sri Lanka",
+  "@countryCodeLK": {
+    "description": "Name of the country 'Sri Lanka'."
+  },
+
+  "countryCodeLR": "Liberia",
+  "@countryCodeLR": {
+    "description": "Name of the country 'Liberia'."
+  },
+
+  "countryCodeLS": "Lesotho",
+  "@countryCodeLS": {
+    "description": "Name of the country 'Lesotho'."
+  },
+
+  "countryCodeLT": "Lithuania",
+  "@countryCodeLT": {
+    "description": "Name of the country 'Lithuania'."
+  },
+
+  "countryCodeLU": "Luxembourg",
+  "@countryCodeLU": {
+    "description": "Name of the country 'Luxembourg'."
+  },
+
+  "countryCodeLV": "Latvia",
+  "@countryCodeLV": {
+    "description": "Name of the country 'Latvia'."
+  },
+
+  "countryCodeLY": "Libya",
+  "@countryCodeLY": {
+    "description": "Name of the country 'Libya'."
+  },
+
+  "countryCodeMA": "Morocco",
+  "@countryCodeMA": {
+    "description": "Name of the country 'Morocco'."
+  },
+
+  "countryCodeMC": "Monaco",
+  "@countryCodeMC": {
+    "description": "Name of the country 'Monaco'."
+  },
+
+  "countryCodeMD": "Moldova, Republic of",
+  "@countryCodeMD": {
+    "description": "Name of the country 'Moldova, Republic of'."
+  },
+
+  "countryCodeME": "Montenegro",
+  "@countryCodeME": {
+    "description": "Name of the country 'Montenegro'."
+  },
+
+  "countryCodeMF": "Saint Martin (French part)",
+  "@countryCodeMF": {
+    "description": "Name of the country 'Saint Martin (French part)'."
+  },
+
+  "countryCodeMG": "Madagascar",
+  "@countryCodeMG": {
+    "description": "Name of the country 'Madagascar'."
+  },
+
+  "countryCodeMH": "Marshall Islands",
+  "@countryCodeMH": {
+    "description": "Name of the country 'Marshall Islands'."
+  },
+
+  "countryCodeMK": "North Macedonia",
+  "@countryCodeMK": {
+    "description": "Name of the country 'North Macedonia'."
+  },
+
+  "countryCodeML": "Mali",
+  "@countryCodeML": {
+    "description": "Name of the country 'Mali'."
+  },
+
+  "countryCodeMM": "Myanmar",
+  "@countryCodeMM": {
+    "description": "Name of the country 'Myanmar'."
+  },
+
+  "countryCodeMN": "Mongolia",
+  "@countryCodeMN": {
+    "description": "Name of the country 'Mongolia'."
+  },
+
+  "countryCodeMO": "Macao",
+  "@countryCodeMO": {
+    "description": "Name of the country 'Macao'."
+  },
+
+  "countryCodeMP": "Northern Mariana Islands",
+  "@countryCodeMP": {
+    "description": "Name of the country 'Northern Mariana Islands'."
+  },
+
+  "countryCodeMQ": "Martinique",
+  "@countryCodeMQ": {
+    "description": "Name of the country 'Martinique'."
+  },
+
+  "countryCodeMR": "Mauritania",
+  "@countryCodeMR": {
+    "description": "Name of the country 'Mauritania'."
+  },
+
+  "countryCodeMS": "Montserrat",
+  "@countryCodeMS": {
+    "description": "Name of the country 'Montserrat'."
+  },
+
+  "countryCodeMT": "Malta",
+  "@countryCodeMT": {
+    "description": "Name of the country 'Malta'."
+  },
+
+  "countryCodeMU": "Mauritius",
+  "@countryCodeMU": {
+    "description": "Name of the country 'Mauritius'."
+  },
+
+  "countryCodeMV": "Maldives",
+  "@countryCodeMV": {
+    "description": "Name of the country 'Maldives'."
+  },
+
+  "countryCodeMW": "Malawi",
+  "@countryCodeMW": {
+    "description": "Name of the country 'Malawi'."
+  },
+
+  "countryCodeMX": "Mexico",
+  "@countryCodeMX": {
+    "description": "Name of the country 'Mexico'."
+  },
+
+  "countryCodeMY": "Malaysia",
+  "@countryCodeMY": {
+    "description": "Name of the country 'Malaysia'."
+  },
+
+  "countryCodeMZ": "Mozambique",
+  "@countryCodeMZ": {
+    "description": "Name of the country 'Mozambique'."
+  },
+
+  "countryCodeNA": "Namibia",
+  "@countryCodeNA": {
+    "description": "Name of the country 'Namibia'."
+  },
+
+  "countryCodeNC": "New Caledonia",
+  "@countryCodeNC": {
+    "description": "Name of the country 'New Caledonia'."
+  },
+
+  "countryCodeNE": "Niger",
+  "@countryCodeNE": {
+    "description": "Name of the country 'Niger'."
+  },
+
+  "countryCodeNF": "Norfolk Island",
+  "@countryCodeNF": {
+    "description": "Name of the country 'Norfolk Island'."
+  },
+
+  "countryCodeNG": "Nigeria",
+  "@countryCodeNG": {
+    "description": "Name of the country 'Nigeria'."
+  },
+
+  "countryCodeNI": "Nicaragua",
+  "@countryCodeNI": {
+    "description": "Name of the country 'Nicaragua'."
+  },
+
+  "countryCodeNL": "Netherlands",
+  "@countryCodeNL": {
+    "description": "Name of the country 'Netherlands'."
+  },
+
+  "countryCodeNO": "Norway",
+  "@countryCodeNO": {
+    "description": "Name of the country 'Norway'."
+  },
+
+  "countryCodeNP": "Nepal",
+  "@countryCodeNP": {
+    "description": "Name of the country 'Nepal'."
+  },
+
+  "countryCodeNR": "Nauru",
+  "@countryCodeNR": {
+    "description": "Name of the country 'Nauru'."
+  },
+
+  "countryCodeNU": "Niue",
+  "@countryCodeNU": {
+    "description": "Name of the country 'Niue'."
+  },
+
+  "countryCodeNZ": "New Zealand",
+  "@countryCodeNZ": {
+    "description": "Name of the country 'New Zealand'."
+  },
+
+  "countryCodeOM": "Oman",
+  "@countryCodeOM": {
+    "description": "Name of the country 'Oman'."
+  },
+
+  "countryCodePA": "Panama",
+  "@countryCodePA": {
+    "description": "Name of the country 'Panama'."
+  },
+
+  "countryCodePE": "Peru",
+  "@countryCodePE": {
+    "description": "Name of the country 'Peru'."
+  },
+
+  "countryCodePF": "French Polynesia",
+  "@countryCodePF": {
+    "description": "Name of the country 'French Polynesia'."
+  },
+
+  "countryCodePG": "Papua New Guinea",
+  "@countryCodePG": {
+    "description": "Name of the country 'Papua New Guinea'."
+  },
+
+  "countryCodePH": "Philippines",
+  "@countryCodePH": {
+    "description": "Name of the country 'Philippines'."
+  },
+
+  "countryCodePK": "Pakistan",
+  "@countryCodePK": {
+    "description": "Name of the country 'Pakistan'."
+  },
+
+  "countryCodePL": "Poland",
+  "@countryCodePL": {
+    "description": "Name of the country 'Poland'."
+  },
+
+  "countryCodePM": "Saint Pierre and Miquelon",
+  "@countryCodePM": {
+    "description": "Name of the country 'Saint Pierre and Miquelon'."
+  },
+
+  "countryCodePN": "Pitcairn",
+  "@countryCodePN": {
+    "description": "Name of the country 'Pitcairn'."
+  },
+
+  "countryCodePR": "Puerto Rico",
+  "@countryCodePR": {
+    "description": "Name of the country 'Puerto Rico'."
+  },
+
+  "countryCodePS": "Palestine, State of",
+  "@countryCodePS": {
+    "description": "Name of the country 'Palestine, State of'."
+  },
+
+  "countryCodePT": "Portugal",
+  "@countryCodePT": {
+    "description": "Name of the country 'Portugal'."
+  },
+
+  "countryCodePW": "Palau",
+  "@countryCodePW": {
+    "description": "Name of the country 'Palau'."
+  },
+
+  "countryCodePY": "Paraguay",
+  "@countryCodePY": {
+    "description": "Name of the country 'Paraguay'."
+  },
+
+  "countryCodeQA": "Qatar",
+  "@countryCodeQA": {
+    "description": "Name of the country 'Qatar'."
+  },
+
+  "countryCodeRE": "Réunion",
+  "@countryCodeRE": {
+    "description": "Name of the country 'Réunion'."
+  },
+
+  "countryCodeRO": "Romania",
+  "@countryCodeRO": {
+    "description": "Name of the country 'Romania'."
+  },
+
+  "countryCodeRS": "Serbia",
+  "@countryCodeRS": {
+    "description": "Name of the country 'Serbia'."
+  },
+
+  "countryCodeRU": "Russian Federation",
+  "@countryCodeRU": {
+    "description": "Name of the country 'Russian Federation'."
+  },
+
+  "countryCodeRW": "Rwanda",
+  "@countryCodeRW": {
+    "description": "Name of the country 'Rwanda'."
+  },
+
+  "countryCodeSA": "Saudi Arabia",
+  "@countryCodeSA": {
+    "description": "Name of the country 'Saudi Arabia'."
+  },
+
+  "countryCodeSB": "Solomon Islands",
+  "@countryCodeSB": {
+    "description": "Name of the country 'Solomon Islands'."
+  },
+
+  "countryCodeSC": "Seychelles",
+  "@countryCodeSC": {
+    "description": "Name of the country 'Seychelles'."
+  },
+
+  "countryCodeSD": "Sudan",
+  "@countryCodeSD": {
+    "description": "Name of the country 'Sudan'."
+  },
+
+  "countryCodeSE": "Sweden",
+  "@countryCodeSE": {
+    "description": "Name of the country 'Sweden'."
+  },
+
+  "countryCodeSG": "Singapore",
+  "@countryCodeSG": {
+    "description": "Name of the country 'Singapore'."
+  },
+
+  "countryCodeSH": "Saint Helena Ascension Tristan da Cunha",
+  "@countryCodeSH": {
+    "description": "Name of the country 'Saint Helena, Ascension and Tristan da Cunha'."
+  },
+
+  "countryCodeSI": "Slovenia",
+  "@countryCodeSI": {
+    "description": "Name of the country 'Slovenia'."
+  },
+
+  "countryCodeSJ": "Svalbard and Jan Mayen",
+  "@countryCodeSJ": {
+    "description": "Name of the country 'Svalbard and Jan Mayen'."
+  },
+
+  "countryCodeSK": "Slovakia",
+  "@countryCodeSK": {
+    "description": "Name of the country 'Slovakia'."
+  },
+
+  "countryCodeSL": "Sierra Leone",
+  "@countryCodeSL": {
+    "description": "Name of the country 'Sierra Leone'."
+  },
+
+  "countryCodeSM": "San Marino",
+  "@countryCodeSM": {
+    "description": "Name of the country 'San Marino'."
+  },
+
+  "countryCodeSN": "Senegal",
+  "@countryCodeSN": {
+    "description": "Name of the country 'Senegal'."
+  },
+
+  "countryCodeSO": "Somalia",
+  "@countryCodeSO": {
+    "description": "Name of the country 'Somalia'."
+  },
+
+  "countryCodeSR": "Suriname",
+  "@countryCodeSR": {
+    "description": "Name of the country 'Suriname'."
+  },
+
+  "countryCodeSS": "South Sudan",
+  "@countryCodeSS": {
+    "description": "Name of the country 'South Sudan'."
+  },
+
+  "countryCodeST": "Sao Tome and Principe",
+  "@countryCodeST": {
+    "description": "Name of the country 'Sao Tome and Principe'."
+  },
+
+  "countryCodeSV": "El Salvador",
+  "@countryCodeSV": {
+    "description": "Name of the country 'El Salvador'."
+  },
+
+  "countryCodeSX": "Sint Maarten (Dutch part)",
+  "@countryCodeSX": {
+    "description": "Name of the country 'Sint Maarten (Dutch part)'."
+  },
+
+  "countryCodeSY": "Syrian Arab Republic",
+  "@countryCodeSY": {
+    "description": "Name of the country 'Syrian Arab Republic'."
+  },
+
+  "countryCodeSZ": "Eswatini",
+  "@countryCodeSZ": {
+    "description": "Name of the country 'Eswatini'."
+  },
+
+  "countryCodeTC": "Turks and Caicos Islands",
+  "@countryCodeTC": {
+    "description": "Name of the country 'Turks and Caicos Islands'."
+  },
+
+  "countryCodeTD": "Chad",
+  "@countryCodeTD": {
+    "description": "Name of the country 'Chad'."
+  },
+
+  "countryCodeTF": "French Southern Territories",
+  "@countryCodeTF": {
+    "description": "Name of the country 'French Southern Territories'."
+  },
+
+  "countryCodeTG": "Togo",
+  "@countryCodeTG": {
+    "description": "Name of the country 'Togo'."
+  },
+
+  "countryCodeTH": "Thailand",
+  "@countryCodeTH": {
+    "description": "Name of the country 'Thailand'."
+  },
+
+  "countryCodeTJ": "Tajikistan",
+  "@countryCodeTJ": {
+    "description": "Name of the country 'Tajikistan'."
+  },
+
+  "countryCodeTK": "Tokelau",
+  "@countryCodeTK": {
+    "description": "Name of the country 'Tokelau'."
+  },
+
+  "countryCodeTL": "Timor-Leste",
+  "@countryCodeTL": {
+    "description": "Name of the country 'Timor-Leste'."
+  },
+
+  "countryCodeTM": "Turkmenistan",
+  "@countryCodeTM": {
+    "description": "Name of the country 'Turkmenistan'."
+  },
+
+  "countryCodeTN": "Tunisia",
+  "@countryCodeTN": {
+    "description": "Name of the country 'Tunisia'."
+  },
+
+  "countryCodeTO": "Tonga",
+  "@countryCodeTO": {
+    "description": "Name of the country 'Tonga'."
+  },
+
+  "countryCodeTR": "Turkey",
+  "@countryCodeTR": {
+    "description": "Name of the country 'Turkey'."
+  },
+
+  "countryCodeTT": "Trinidad and Tobago",
+  "@countryCodeTT": {
+    "description": "Name of the country 'Trinidad and Tobago'."
+  },
+
+  "countryCodeTV": "Tuvalu",
+  "@countryCodeTV": {
+    "description": "Name of the country 'Tuvalu'."
+  },
+
+  "countryCodeTW": "Taiwan, Province of China",
+  "@countryCodeTW": {
+    "description": "Name of the country 'Taiwan, Province of China'."
+  },
+
+  "countryCodeTZ": "Tanzania, United Republic of",
+  "@countryCodeTZ": {
+    "description": "Name of the country 'Tanzania, United Republic of'."
+  },
+
+  "countryCodeUA": "Ukraine",
+  "@countryCodeUA": {
+    "description": "Name of the country 'Ukraine'."
+  },
+
+  "countryCodeUG": "Uganda",
+  "@countryCodeUG": {
+    "description": "Name of the country 'Uganda'."
+  },
+
+  "countryCodeUM": "United States Minor Outlying Islands",
+  "@countryCodeUM": {
+    "description": "Name of the country 'United States Minor Outlying Islands'."
+  },
+
+  "countryCodeUS": "United States of America",
+  "@countryCodeUS": {
+    "description": "Name of the country 'United States of America'."
+  },
+
+  "countryCodeUY": "Uruguay",
+  "@countryCodeUY": {
+    "description": "Name of the country 'Uruguay'."
+  },
+
+  "countryCodeUZ": "Uzbekistan",
+  "@countryCodeUZ": {
+    "description": "Name of the country 'Uzbekistan'."
+  },
+
+  "countryCodeVA": "Holy See",
+  "@countryCodeVA": {
+    "description": "Name of the country 'Holy See'."
+  },
+
+  "countryCodeVC": "Saint Vincent and the Grenadines",
+  "@countryCodeVC": {
+    "description": "Name of the country 'Saint Vincent and the Grenadines'."
+  },
+
+  "countryCodeVE": "Venezuela (Bolivarian Republic of)",
+  "@countryCodeVE": {
+    "description": "Name of the country 'Venezuela (Bolivarian Republic of)'."
+  },
+
+  "countryCodeVG": "Virgin Islands (British)",
+  "@countryCodeVG": {
+    "description": "Name of the country 'Virgin Islands (British)'."
+  },
+
+  "countryCodeVI": "Virgin Islands (U.S.)",
+  "@countryCodeVI": {
+    "description": "Name of the country 'Virgin Islands (U.S.)'."
+  },
+
+  "countryCodeVN": "Viet Nam",
+  "@countryCodeVN": {
+    "description": "Name of the country 'Viet Nam'."
+  },
+
+  "countryCodeVU": "Vanuatu",
+  "@countryCodeVU": {
+    "description": "Name of the country 'Vanuatu'."
+  },
+
+  "countryCodeWF": "Wallis and Futuna",
+  "@countryCodeWF": {
+    "description": "Name of the country 'Wallis and Futuna'."
+  },
+
+  "countryCodeWS": "Samoa",
+  "@countryCodeWS": {
+    "description": "Name of the country 'Samoa'."
+  },
+
+  "countryCodeYE": "Yemen",
+  "@countryCodeYE": {
+    "description": "Name of the country 'Yemen'."
+  },
+
+  "countryCodeYT": "Mayotte",
+  "@countryCodeYT": {
+    "description": "Name of the country 'Mayotte'."
+  },
+
+  "countryCodeZA": "South Africa",
+  "@countryCodeZA": {
+    "description": "Name of the country 'South Africa'."
+  },
+
+  "countryCodeZM": "Zambia",
+  "@countryCodeZM": {
+    "description": "Name of the country 'Zambia'."
+  },
+
+  "countryCodeZW": "Zimbabwe",
+  "@countryCodeZW": {
+    "description": "Name of the country 'Zimbabwe'."
   }
+
 }

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -446,6 +446,12 @@ abstract class AppLocalizations {
   // Menu item displayed with no country is yet selected.
   String get locationStepNoCountrySelected;
 
+  // Menu item displayed with no country is yet selected.
+  String get locationStepCountrySearchPrompt;
+
+  // Label for the dropdown button that selects a country.
+  String get locationStepCountryButtonLabel;
+
   // Name of the country 'Andorra'.
   String get countryCodeAD;
 

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -442,6 +442,756 @@ abstract class AppLocalizations {
 
   // Let the user that they can scroll to see more content
   String get scrollMoreIndicatorMessage;
+
+  // Menu item displayed with no country is yet selected.
+  String get locationStepNoCountrySelected;
+
+  // Name of the country 'Andorra'.
+  String get countryCodeAD;
+
+  // Name of the country 'United Arab Emirates'.
+  String get countryCodeAE;
+
+  // Name of the country 'Afghanistan'.
+  String get countryCodeAF;
+
+  // Name of the country 'Antigua and Barbuda'.
+  String get countryCodeAG;
+
+  // Name of the country 'Anguilla'.
+  String get countryCodeAI;
+
+  // Name of the country 'Albania'.
+  String get countryCodeAL;
+
+  // Name of the country 'Armenia'.
+  String get countryCodeAM;
+
+  // Name of the country 'Angola'.
+  String get countryCodeAO;
+
+  // Name of the country 'Antarctica'.
+  String get countryCodeAQ;
+
+  // Name of the country 'Argentina'.
+  String get countryCodeAR;
+
+  // Name of the country 'American Samoa'.
+  String get countryCodeAS;
+
+  // Name of the country 'Austria'.
+  String get countryCodeAT;
+
+  // Name of the country 'Australia'.
+  String get countryCodeAU;
+
+  // Name of the country 'Aruba'.
+  String get countryCodeAW;
+
+  // Name of the country 'Åland Islands'.
+  String get countryCodeAX;
+
+  // Name of the country 'Azerbaijan'.
+  String get countryCodeAZ;
+
+  // Name of the country 'Bosnia and Herzegovina'.
+  String get countryCodeBA;
+
+  // Name of the country 'Barbados'.
+  String get countryCodeBB;
+
+  // Name of the country 'Bangladesh'.
+  String get countryCodeBD;
+
+  // Name of the country 'Belgium'.
+  String get countryCodeBE;
+
+  // Name of the country 'Burkina Faso'.
+  String get countryCodeBF;
+
+  // Name of the country 'Bulgaria'.
+  String get countryCodeBG;
+
+  // Name of the country 'Bahrain'.
+  String get countryCodeBH;
+
+  // Name of the country 'Burundi'.
+  String get countryCodeBI;
+
+  // Name of the country 'Benin'.
+  String get countryCodeBJ;
+
+  // Name of the country 'Saint Barthélemy'.
+  String get countryCodeBL;
+
+  // Name of the country 'Bermuda'.
+  String get countryCodeBM;
+
+  // Name of the country 'Brunei Darussalam'.
+  String get countryCodeBN;
+
+  // Name of the country 'Bolivia (Plurinational State of)'.
+  String get countryCodeBO;
+
+  // Name of the country 'Bonaire, Sint Eustatius and Saba'.
+  String get countryCodeBQ;
+
+  // Name of the country 'Brazil'.
+  String get countryCodeBR;
+
+  // Name of the country 'Bahamas'.
+  String get countryCodeBS;
+
+  // Name of the country 'Bhutan'.
+  String get countryCodeBT;
+
+  // Name of the country 'Bouvet Island'.
+  String get countryCodeBV;
+
+  // Name of the country 'Botswana'.
+  String get countryCodeBW;
+
+  // Name of the country 'Belarus'.
+  String get countryCodeBY;
+
+  // Name of the country 'Belize'.
+  String get countryCodeBZ;
+
+  // Name of the country 'Canada'.
+  String get countryCodeCA;
+
+  // Name of the country 'Cocos (Keeling) Islands'.
+  String get countryCodeCC;
+
+  // Name of the country 'Congo, Democratic Republic of the'.
+  String get countryCodeCD;
+
+  // Name of the country 'Central African Republic'.
+  String get countryCodeCF;
+
+  // Name of the country 'Congo'.
+  String get countryCodeCG;
+
+  // Name of the country 'Switzerland'.
+  String get countryCodeCH;
+
+  // Name of the country 'Côte d'Ivoire'.
+  String get countryCodeCI;
+
+  // Name of the country 'Cook Islands'.
+  String get countryCodeCK;
+
+  // Name of the country 'Chile'.
+  String get countryCodeCL;
+
+  // Name of the country 'Cameroon'.
+  String get countryCodeCM;
+
+  // Name of the country 'China'.
+  String get countryCodeCN;
+
+  // Name of the country 'Colombia'.
+  String get countryCodeCO;
+
+  // Name of the country 'Costa Rica'.
+  String get countryCodeCR;
+
+  // Name of the country 'Cuba'.
+  String get countryCodeCU;
+
+  // Name of the country 'Cabo Verde'.
+  String get countryCodeCV;
+
+  // Name of the country 'Curaçao'.
+  String get countryCodeCW;
+
+  // Name of the country 'Christmas Island'.
+  String get countryCodeCX;
+
+  // Name of the country 'Cyprus'.
+  String get countryCodeCY;
+
+  // Name of the country 'Czechia'.
+  String get countryCodeCZ;
+
+  // Name of the country 'Germany'.
+  String get countryCodeDE;
+
+  // Name of the country 'Djibouti'.
+  String get countryCodeDJ;
+
+  // Name of the country 'Denmark'.
+  String get countryCodeDK;
+
+  // Name of the country 'Dominica'.
+  String get countryCodeDM;
+
+  // Name of the country 'Dominican Republic'.
+  String get countryCodeDO;
+
+  // Name of the country 'Algeria'.
+  String get countryCodeDZ;
+
+  // Name of the country 'Ecuador'.
+  String get countryCodeEC;
+
+  // Name of the country 'Estonia'.
+  String get countryCodeEE;
+
+  // Name of the country 'Egypt'.
+  String get countryCodeEG;
+
+  // Name of the country 'Western Sahara'.
+  String get countryCodeEH;
+
+  // Name of the country 'Eritrea'.
+  String get countryCodeER;
+
+  // Name of the country 'Spain'.
+  String get countryCodeES;
+
+  // Name of the country 'Ethiopia'.
+  String get countryCodeET;
+
+  // Name of the country 'Finland'.
+  String get countryCodeFI;
+
+  // Name of the country 'Fiji'.
+  String get countryCodeFJ;
+
+  // Name of the country 'Falkland Islands (Malvinas)'.
+  String get countryCodeFK;
+
+  // Name of the country 'Micronesia (Federated States of)'.
+  String get countryCodeFM;
+
+  // Name of the country 'Faroe Islands'.
+  String get countryCodeFO;
+
+  // Name of the country 'France'.
+  String get countryCodeFR;
+
+  // Name of the country 'Gabon'.
+  String get countryCodeGA;
+
+  // Name of the country 'United Kingdom'.
+  String get countryCodeGB;
+
+  // Name of the country 'Grenada'.
+  String get countryCodeGD;
+
+  // Name of the country 'Georgia'.
+  String get countryCodeGE;
+
+  // Name of the country 'French Guiana'.
+  String get countryCodeGF;
+
+  // Name of the country 'Guernsey'.
+  String get countryCodeGG;
+
+  // Name of the country 'Ghana'.
+  String get countryCodeGH;
+
+  // Name of the country 'Gibraltar'.
+  String get countryCodeGI;
+
+  // Name of the country 'Greenland'.
+  String get countryCodeGL;
+
+  // Name of the country 'Gambia'.
+  String get countryCodeGM;
+
+  // Name of the country 'Guinea'.
+  String get countryCodeGN;
+
+  // Name of the country 'Guadeloupe'.
+  String get countryCodeGP;
+
+  // Name of the country 'Equatorial Guinea'.
+  String get countryCodeGQ;
+
+  // Name of the country 'Greece'.
+  String get countryCodeGR;
+
+  // Name of the country 'South Georgia and the South Sandwich Islands'.
+  String get countryCodeGS;
+
+  // Name of the country 'Guatemala'.
+  String get countryCodeGT;
+
+  // Name of the country 'Guam'.
+  String get countryCodeGU;
+
+  // Name of the country 'Guinea-Bissau'.
+  String get countryCodeGW;
+
+  // Name of the country 'Guyana'.
+  String get countryCodeGY;
+
+  // Name of the country 'Hong Kong'.
+  String get countryCodeHK;
+
+  // Name of the country 'Heard Island and McDonald Islands'.
+  String get countryCodeHM;
+
+  // Name of the country 'Honduras'.
+  String get countryCodeHN;
+
+  // Name of the country 'Croatia'.
+  String get countryCodeHR;
+
+  // Name of the country 'Haiti'.
+  String get countryCodeHT;
+
+  // Name of the country 'Hungary'.
+  String get countryCodeHU;
+
+  // Name of the country 'Indonesia'.
+  String get countryCodeID;
+
+  // Name of the country 'Ireland'.
+  String get countryCodeIE;
+
+  // Name of the country 'Israel'.
+  String get countryCodeIL;
+
+  // Name of the country 'Isle of Man'.
+  String get countryCodeIM;
+
+  // Name of the country 'India'.
+  String get countryCodeIN;
+
+  // Name of the country 'British Indian Ocean Territory'.
+  String get countryCodeIO;
+
+  // Name of the country 'Iraq'.
+  String get countryCodeIQ;
+
+  // Name of the country 'Iran (Islamic Republic of)'.
+  String get countryCodeIR;
+
+  // Name of the country 'Iceland'.
+  String get countryCodeIS;
+
+  // Name of the country 'Italy'.
+  String get countryCodeIT;
+
+  // Name of the country 'Jersey'.
+  String get countryCodeJE;
+
+  // Name of the country 'Jamaica'.
+  String get countryCodeJM;
+
+  // Name of the country 'Jordan'.
+  String get countryCodeJO;
+
+  // Name of the country 'Japan'.
+  String get countryCodeJP;
+
+  // Name of the country 'Kenya'.
+  String get countryCodeKE;
+
+  // Name of the country 'Kyrgyzstan'.
+  String get countryCodeKG;
+
+  // Name of the country 'Cambodia'.
+  String get countryCodeKH;
+
+  // Name of the country 'Kiribati'.
+  String get countryCodeKI;
+
+  // Name of the country 'Comoros'.
+  String get countryCodeKM;
+
+  // Name of the country 'Saint Kitts and Nevis'.
+  String get countryCodeKN;
+
+  // Name of the country 'Korea (Democratic People's Republic of)'.
+  String get countryCodeKP;
+
+  // Name of the country 'Korea, Republic of'.
+  String get countryCodeKR;
+
+  // Name of the country 'Kuwait'.
+  String get countryCodeKW;
+
+  // Name of the country 'Cayman Islands'.
+  String get countryCodeKY;
+
+  // Name of the country 'Kazakhstan'.
+  String get countryCodeKZ;
+
+  // Name of the country 'Lao People's Democratic Republic'.
+  String get countryCodeLA;
+
+  // Name of the country 'Lebanon'.
+  String get countryCodeLB;
+
+  // Name of the country 'Saint Lucia'.
+  String get countryCodeLC;
+
+  // Name of the country 'Liechtenstein'.
+  String get countryCodeLI;
+
+  // Name of the country 'Sri Lanka'.
+  String get countryCodeLK;
+
+  // Name of the country 'Liberia'.
+  String get countryCodeLR;
+
+  // Name of the country 'Lesotho'.
+  String get countryCodeLS;
+
+  // Name of the country 'Lithuania'.
+  String get countryCodeLT;
+
+  // Name of the country 'Luxembourg'.
+  String get countryCodeLU;
+
+  // Name of the country 'Latvia'.
+  String get countryCodeLV;
+
+  // Name of the country 'Libya'.
+  String get countryCodeLY;
+
+  // Name of the country 'Morocco'.
+  String get countryCodeMA;
+
+  // Name of the country 'Monaco'.
+  String get countryCodeMC;
+
+  // Name of the country 'Moldova, Republic of'.
+  String get countryCodeMD;
+
+  // Name of the country 'Montenegro'.
+  String get countryCodeME;
+
+  // Name of the country 'Saint Martin (French part)'.
+  String get countryCodeMF;
+
+  // Name of the country 'Madagascar'.
+  String get countryCodeMG;
+
+  // Name of the country 'Marshall Islands'.
+  String get countryCodeMH;
+
+  // Name of the country 'North Macedonia'.
+  String get countryCodeMK;
+
+  // Name of the country 'Mali'.
+  String get countryCodeML;
+
+  // Name of the country 'Myanmar'.
+  String get countryCodeMM;
+
+  // Name of the country 'Mongolia'.
+  String get countryCodeMN;
+
+  // Name of the country 'Macao'.
+  String get countryCodeMO;
+
+  // Name of the country 'Northern Mariana Islands'.
+  String get countryCodeMP;
+
+  // Name of the country 'Martinique'.
+  String get countryCodeMQ;
+
+  // Name of the country 'Mauritania'.
+  String get countryCodeMR;
+
+  // Name of the country 'Montserrat'.
+  String get countryCodeMS;
+
+  // Name of the country 'Malta'.
+  String get countryCodeMT;
+
+  // Name of the country 'Mauritius'.
+  String get countryCodeMU;
+
+  // Name of the country 'Maldives'.
+  String get countryCodeMV;
+
+  // Name of the country 'Malawi'.
+  String get countryCodeMW;
+
+  // Name of the country 'Mexico'.
+  String get countryCodeMX;
+
+  // Name of the country 'Malaysia'.
+  String get countryCodeMY;
+
+  // Name of the country 'Mozambique'.
+  String get countryCodeMZ;
+
+  // Name of the country 'Namibia'.
+  String get countryCodeNA;
+
+  // Name of the country 'New Caledonia'.
+  String get countryCodeNC;
+
+  // Name of the country 'Niger'.
+  String get countryCodeNE;
+
+  // Name of the country 'Norfolk Island'.
+  String get countryCodeNF;
+
+  // Name of the country 'Nigeria'.
+  String get countryCodeNG;
+
+  // Name of the country 'Nicaragua'.
+  String get countryCodeNI;
+
+  // Name of the country 'Netherlands'.
+  String get countryCodeNL;
+
+  // Name of the country 'Norway'.
+  String get countryCodeNO;
+
+  // Name of the country 'Nepal'.
+  String get countryCodeNP;
+
+  // Name of the country 'Nauru'.
+  String get countryCodeNR;
+
+  // Name of the country 'Niue'.
+  String get countryCodeNU;
+
+  // Name of the country 'New Zealand'.
+  String get countryCodeNZ;
+
+  // Name of the country 'Oman'.
+  String get countryCodeOM;
+
+  // Name of the country 'Panama'.
+  String get countryCodePA;
+
+  // Name of the country 'Peru'.
+  String get countryCodePE;
+
+  // Name of the country 'French Polynesia'.
+  String get countryCodePF;
+
+  // Name of the country 'Papua New Guinea'.
+  String get countryCodePG;
+
+  // Name of the country 'Philippines'.
+  String get countryCodePH;
+
+  // Name of the country 'Pakistan'.
+  String get countryCodePK;
+
+  // Name of the country 'Poland'.
+  String get countryCodePL;
+
+  // Name of the country 'Saint Pierre and Miquelon'.
+  String get countryCodePM;
+
+  // Name of the country 'Pitcairn'.
+  String get countryCodePN;
+
+  // Name of the country 'Puerto Rico'.
+  String get countryCodePR;
+
+  // Name of the country 'Palestine, State of'.
+  String get countryCodePS;
+
+  // Name of the country 'Portugal'.
+  String get countryCodePT;
+
+  // Name of the country 'Palau'.
+  String get countryCodePW;
+
+  // Name of the country 'Paraguay'.
+  String get countryCodePY;
+
+  // Name of the country 'Qatar'.
+  String get countryCodeQA;
+
+  // Name of the country 'Réunion'.
+  String get countryCodeRE;
+
+  // Name of the country 'Romania'.
+  String get countryCodeRO;
+
+  // Name of the country 'Serbia'.
+  String get countryCodeRS;
+
+  // Name of the country 'Russian Federation'.
+  String get countryCodeRU;
+
+  // Name of the country 'Rwanda'.
+  String get countryCodeRW;
+
+  // Name of the country 'Saudi Arabia'.
+  String get countryCodeSA;
+
+  // Name of the country 'Solomon Islands'.
+  String get countryCodeSB;
+
+  // Name of the country 'Seychelles'.
+  String get countryCodeSC;
+
+  // Name of the country 'Sudan'.
+  String get countryCodeSD;
+
+  // Name of the country 'Sweden'.
+  String get countryCodeSE;
+
+  // Name of the country 'Singapore'.
+  String get countryCodeSG;
+
+  // Name of the country 'Saint Helena, Ascension and Tristan da Cunha'.
+  String get countryCodeSH;
+
+  // Name of the country 'Slovenia'.
+  String get countryCodeSI;
+
+  // Name of the country 'Svalbard and Jan Mayen'.
+  String get countryCodeSJ;
+
+  // Name of the country 'Slovakia'.
+  String get countryCodeSK;
+
+  // Name of the country 'Sierra Leone'.
+  String get countryCodeSL;
+
+  // Name of the country 'San Marino'.
+  String get countryCodeSM;
+
+  // Name of the country 'Senegal'.
+  String get countryCodeSN;
+
+  // Name of the country 'Somalia'.
+  String get countryCodeSO;
+
+  // Name of the country 'Suriname'.
+  String get countryCodeSR;
+
+  // Name of the country 'South Sudan'.
+  String get countryCodeSS;
+
+  // Name of the country 'Sao Tome and Principe'.
+  String get countryCodeST;
+
+  // Name of the country 'El Salvador'.
+  String get countryCodeSV;
+
+  // Name of the country 'Sint Maarten (Dutch part)'.
+  String get countryCodeSX;
+
+  // Name of the country 'Syrian Arab Republic'.
+  String get countryCodeSY;
+
+  // Name of the country 'Eswatini'.
+  String get countryCodeSZ;
+
+  // Name of the country 'Turks and Caicos Islands'.
+  String get countryCodeTC;
+
+  // Name of the country 'Chad'.
+  String get countryCodeTD;
+
+  // Name of the country 'French Southern Territories'.
+  String get countryCodeTF;
+
+  // Name of the country 'Togo'.
+  String get countryCodeTG;
+
+  // Name of the country 'Thailand'.
+  String get countryCodeTH;
+
+  // Name of the country 'Tajikistan'.
+  String get countryCodeTJ;
+
+  // Name of the country 'Tokelau'.
+  String get countryCodeTK;
+
+  // Name of the country 'Timor-Leste'.
+  String get countryCodeTL;
+
+  // Name of the country 'Turkmenistan'.
+  String get countryCodeTM;
+
+  // Name of the country 'Tunisia'.
+  String get countryCodeTN;
+
+  // Name of the country 'Tonga'.
+  String get countryCodeTO;
+
+  // Name of the country 'Turkey'.
+  String get countryCodeTR;
+
+  // Name of the country 'Trinidad and Tobago'.
+  String get countryCodeTT;
+
+  // Name of the country 'Tuvalu'.
+  String get countryCodeTV;
+
+  // Name of the country 'Taiwan, Province of China'.
+  String get countryCodeTW;
+
+  // Name of the country 'Tanzania, United Republic of'.
+  String get countryCodeTZ;
+
+  // Name of the country 'Ukraine'.
+  String get countryCodeUA;
+
+  // Name of the country 'Uganda'.
+  String get countryCodeUG;
+
+  // Name of the country 'United States Minor Outlying Islands'.
+  String get countryCodeUM;
+
+  // Name of the country 'United States of America'.
+  String get countryCodeUS;
+
+  // Name of the country 'Uruguay'.
+  String get countryCodeUY;
+
+  // Name of the country 'Uzbekistan'.
+  String get countryCodeUZ;
+
+  // Name of the country 'Holy See'.
+  String get countryCodeVA;
+
+  // Name of the country 'Saint Vincent and the Grenadines'.
+  String get countryCodeVC;
+
+  // Name of the country 'Venezuela (Bolivarian Republic of)'.
+  String get countryCodeVE;
+
+  // Name of the country 'Virgin Islands (British)'.
+  String get countryCodeVG;
+
+  // Name of the country 'Virgin Islands (U.S.)'.
+  String get countryCodeVI;
+
+  // Name of the country 'Viet Nam'.
+  String get countryCodeVN;
+
+  // Name of the country 'Vanuatu'.
+  String get countryCodeVU;
+
+  // Name of the country 'Wallis and Futuna'.
+  String get countryCodeWF;
+
+  // Name of the country 'Samoa'.
+  String get countryCodeWS;
+
+  // Name of the country 'Yemen'.
+  String get countryCodeYE;
+
+  // Name of the country 'Mayotte'.
+  String get countryCodeYT;
+
+  // Name of the country 'South Africa'.
+  String get countryCodeZA;
+
+  // Name of the country 'Zambia'.
+  String get countryCodeZM;
+
+  // Name of the country 'Zimbabwe'.
+  String get countryCodeZW;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -425,6 +425,13 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get locationStepNoCountrySelected => 'None selected';
 
   @override
+  String get locationStepCountrySearchPrompt =>
+      'Please select the country where you are located';
+
+  @override
+  String get locationStepCountryButtonLabel => 'Country:';
+
+  @override
   String get countryCodeAD => 'Andorra';
 
   @override

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -420,4 +420,754 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
 
   @override
   String get scrollMoreIndicatorMessage => 'SCROLL FOR MORE';
+
+  @override
+  String get locationStepNoCountrySelected => 'None selected';
+
+  @override
+  String get countryCodeAD => 'Andorra';
+
+  @override
+  String get countryCodeAE => 'United Arab Emirates';
+
+  @override
+  String get countryCodeAF => 'Afghanistan';
+
+  @override
+  String get countryCodeAG => 'Antigua and Barbuda';
+
+  @override
+  String get countryCodeAI => 'Anguilla';
+
+  @override
+  String get countryCodeAL => 'Albania';
+
+  @override
+  String get countryCodeAM => 'Armenia';
+
+  @override
+  String get countryCodeAO => 'Angola';
+
+  @override
+  String get countryCodeAQ => 'Antarctica';
+
+  @override
+  String get countryCodeAR => 'Argentina';
+
+  @override
+  String get countryCodeAS => 'American Samoa';
+
+  @override
+  String get countryCodeAT => 'Austria';
+
+  @override
+  String get countryCodeAU => 'Australia';
+
+  @override
+  String get countryCodeAW => 'Aruba';
+
+  @override
+  String get countryCodeAX => 'Åland Islands';
+
+  @override
+  String get countryCodeAZ => 'Azerbaijan';
+
+  @override
+  String get countryCodeBA => 'Bosnia and Herzegovina';
+
+  @override
+  String get countryCodeBB => 'Barbados';
+
+  @override
+  String get countryCodeBD => 'Bangladesh';
+
+  @override
+  String get countryCodeBE => 'Belgium';
+
+  @override
+  String get countryCodeBF => 'Burkina Faso';
+
+  @override
+  String get countryCodeBG => 'Bulgaria';
+
+  @override
+  String get countryCodeBH => 'Bahrain';
+
+  @override
+  String get countryCodeBI => 'Burundi';
+
+  @override
+  String get countryCodeBJ => 'Benin';
+
+  @override
+  String get countryCodeBL => 'Saint Barthélemy';
+
+  @override
+  String get countryCodeBM => 'Bermuda';
+
+  @override
+  String get countryCodeBN => 'Brunei Darussalam';
+
+  @override
+  String get countryCodeBO => 'Bolivia (Plurinational State of)';
+
+  @override
+  String get countryCodeBQ => 'Bonaire, Sint Eustatius and Saba';
+
+  @override
+  String get countryCodeBR => 'Brazil';
+
+  @override
+  String get countryCodeBS => 'Bahamas';
+
+  @override
+  String get countryCodeBT => 'Bhutan';
+
+  @override
+  String get countryCodeBV => 'Bouvet Island';
+
+  @override
+  String get countryCodeBW => 'Botswana';
+
+  @override
+  String get countryCodeBY => 'Belarus';
+
+  @override
+  String get countryCodeBZ => 'Belize';
+
+  @override
+  String get countryCodeCA => 'Canada';
+
+  @override
+  String get countryCodeCC => 'Cocos (Keeling) Islands';
+
+  @override
+  String get countryCodeCD => 'Congo, Democratic Republic of the';
+
+  @override
+  String get countryCodeCF => 'Central African Republic';
+
+  @override
+  String get countryCodeCG => 'Congo';
+
+  @override
+  String get countryCodeCH => 'Switzerland';
+
+  @override
+  String get countryCodeCI => 'Côte d\'Ivoire';
+
+  @override
+  String get countryCodeCK => 'Cook Islands';
+
+  @override
+  String get countryCodeCL => 'Chile';
+
+  @override
+  String get countryCodeCM => 'Cameroon';
+
+  @override
+  String get countryCodeCN => 'China';
+
+  @override
+  String get countryCodeCO => 'Colombia';
+
+  @override
+  String get countryCodeCR => 'Costa Rica';
+
+  @override
+  String get countryCodeCU => 'Cuba';
+
+  @override
+  String get countryCodeCV => 'Cabo Verde';
+
+  @override
+  String get countryCodeCW => 'Curaçao';
+
+  @override
+  String get countryCodeCX => 'Christmas Island';
+
+  @override
+  String get countryCodeCY => 'Cyprus';
+
+  @override
+  String get countryCodeCZ => 'Czechia';
+
+  @override
+  String get countryCodeDE => 'Germany';
+
+  @override
+  String get countryCodeDJ => 'Djibouti';
+
+  @override
+  String get countryCodeDK => 'Denmark';
+
+  @override
+  String get countryCodeDM => 'Dominica';
+
+  @override
+  String get countryCodeDO => 'Dominican Republic';
+
+  @override
+  String get countryCodeDZ => 'Algeria';
+
+  @override
+  String get countryCodeEC => 'Ecuador';
+
+  @override
+  String get countryCodeEE => 'Estonia';
+
+  @override
+  String get countryCodeEG => 'Egypt';
+
+  @override
+  String get countryCodeEH => 'Western Sahara';
+
+  @override
+  String get countryCodeER => 'Eritrea';
+
+  @override
+  String get countryCodeES => 'Spain';
+
+  @override
+  String get countryCodeET => 'Ethiopia';
+
+  @override
+  String get countryCodeFI => 'Finland';
+
+  @override
+  String get countryCodeFJ => 'Fiji';
+
+  @override
+  String get countryCodeFK => 'Falkland Islands (Malvinas)';
+
+  @override
+  String get countryCodeFM => 'Micronesia (Federated States of)';
+
+  @override
+  String get countryCodeFO => 'Faroe Islands';
+
+  @override
+  String get countryCodeFR => 'France';
+
+  @override
+  String get countryCodeGA => 'Gabon';
+
+  @override
+  String get countryCodeGB => 'United Kingdom';
+
+  @override
+  String get countryCodeGD => 'Grenada';
+
+  @override
+  String get countryCodeGE => 'Georgia';
+
+  @override
+  String get countryCodeGF => 'French Guiana';
+
+  @override
+  String get countryCodeGG => 'Guernsey';
+
+  @override
+  String get countryCodeGH => 'Ghana';
+
+  @override
+  String get countryCodeGI => 'Gibraltar';
+
+  @override
+  String get countryCodeGL => 'Greenland';
+
+  @override
+  String get countryCodeGM => 'Gambia';
+
+  @override
+  String get countryCodeGN => 'Guinea';
+
+  @override
+  String get countryCodeGP => 'Guadeloupe';
+
+  @override
+  String get countryCodeGQ => 'Equatorial Guinea';
+
+  @override
+  String get countryCodeGR => 'Greece';
+
+  @override
+  String get countryCodeGS => 'South Georgia and the South Sandwich Islands';
+
+  @override
+  String get countryCodeGT => 'Guatemala';
+
+  @override
+  String get countryCodeGU => 'Guam';
+
+  @override
+  String get countryCodeGW => 'Guinea-Bissau';
+
+  @override
+  String get countryCodeGY => 'Guyana';
+
+  @override
+  String get countryCodeHK => 'Hong Kong';
+
+  @override
+  String get countryCodeHM => 'Heard Island and McDonald Islands';
+
+  @override
+  String get countryCodeHN => 'Honduras';
+
+  @override
+  String get countryCodeHR => 'Croatia';
+
+  @override
+  String get countryCodeHT => 'Haiti';
+
+  @override
+  String get countryCodeHU => 'Hungary';
+
+  @override
+  String get countryCodeID => 'Indonesia';
+
+  @override
+  String get countryCodeIE => 'Ireland';
+
+  @override
+  String get countryCodeIL => 'Israel';
+
+  @override
+  String get countryCodeIM => 'Isle of Man';
+
+  @override
+  String get countryCodeIN => 'India';
+
+  @override
+  String get countryCodeIO => 'British Indian Ocean Territory';
+
+  @override
+  String get countryCodeIQ => 'Iraq';
+
+  @override
+  String get countryCodeIR => 'Iran (Islamic Republic of)';
+
+  @override
+  String get countryCodeIS => 'Iceland';
+
+  @override
+  String get countryCodeIT => 'Italy';
+
+  @override
+  String get countryCodeJE => 'Jersey';
+
+  @override
+  String get countryCodeJM => 'Jamaica';
+
+  @override
+  String get countryCodeJO => 'Jordan';
+
+  @override
+  String get countryCodeJP => 'Japan';
+
+  @override
+  String get countryCodeKE => 'Kenya';
+
+  @override
+  String get countryCodeKG => 'Kyrgyzstan';
+
+  @override
+  String get countryCodeKH => 'Cambodia';
+
+  @override
+  String get countryCodeKI => 'Kiribati';
+
+  @override
+  String get countryCodeKM => 'Comoros';
+
+  @override
+  String get countryCodeKN => 'Saint Kitts and Nevis';
+
+  @override
+  String get countryCodeKP => 'Korea (Democratic People\'s Republic of)';
+
+  @override
+  String get countryCodeKR => 'Korea, Republic of';
+
+  @override
+  String get countryCodeKW => 'Kuwait';
+
+  @override
+  String get countryCodeKY => 'Cayman Islands';
+
+  @override
+  String get countryCodeKZ => 'Kazakhstan';
+
+  @override
+  String get countryCodeLA => 'Lao People\'s Democratic Republic';
+
+  @override
+  String get countryCodeLB => 'Lebanon';
+
+  @override
+  String get countryCodeLC => 'Saint Lucia';
+
+  @override
+  String get countryCodeLI => 'Liechtenstein';
+
+  @override
+  String get countryCodeLK => 'Sri Lanka';
+
+  @override
+  String get countryCodeLR => 'Liberia';
+
+  @override
+  String get countryCodeLS => 'Lesotho';
+
+  @override
+  String get countryCodeLT => 'Lithuania';
+
+  @override
+  String get countryCodeLU => 'Luxembourg';
+
+  @override
+  String get countryCodeLV => 'Latvia';
+
+  @override
+  String get countryCodeLY => 'Libya';
+
+  @override
+  String get countryCodeMA => 'Morocco';
+
+  @override
+  String get countryCodeMC => 'Monaco';
+
+  @override
+  String get countryCodeMD => 'Moldova, Republic of';
+
+  @override
+  String get countryCodeME => 'Montenegro';
+
+  @override
+  String get countryCodeMF => 'Saint Martin (French part)';
+
+  @override
+  String get countryCodeMG => 'Madagascar';
+
+  @override
+  String get countryCodeMH => 'Marshall Islands';
+
+  @override
+  String get countryCodeMK => 'North Macedonia';
+
+  @override
+  String get countryCodeML => 'Mali';
+
+  @override
+  String get countryCodeMM => 'Myanmar';
+
+  @override
+  String get countryCodeMN => 'Mongolia';
+
+  @override
+  String get countryCodeMO => 'Macao';
+
+  @override
+  String get countryCodeMP => 'Northern Mariana Islands';
+
+  @override
+  String get countryCodeMQ => 'Martinique';
+
+  @override
+  String get countryCodeMR => 'Mauritania';
+
+  @override
+  String get countryCodeMS => 'Montserrat';
+
+  @override
+  String get countryCodeMT => 'Malta';
+
+  @override
+  String get countryCodeMU => 'Mauritius';
+
+  @override
+  String get countryCodeMV => 'Maldives';
+
+  @override
+  String get countryCodeMW => 'Malawi';
+
+  @override
+  String get countryCodeMX => 'Mexico';
+
+  @override
+  String get countryCodeMY => 'Malaysia';
+
+  @override
+  String get countryCodeMZ => 'Mozambique';
+
+  @override
+  String get countryCodeNA => 'Namibia';
+
+  @override
+  String get countryCodeNC => 'New Caledonia';
+
+  @override
+  String get countryCodeNE => 'Niger';
+
+  @override
+  String get countryCodeNF => 'Norfolk Island';
+
+  @override
+  String get countryCodeNG => 'Nigeria';
+
+  @override
+  String get countryCodeNI => 'Nicaragua';
+
+  @override
+  String get countryCodeNL => 'Netherlands';
+
+  @override
+  String get countryCodeNO => 'Norway';
+
+  @override
+  String get countryCodeNP => 'Nepal';
+
+  @override
+  String get countryCodeNR => 'Nauru';
+
+  @override
+  String get countryCodeNU => 'Niue';
+
+  @override
+  String get countryCodeNZ => 'New Zealand';
+
+  @override
+  String get countryCodeOM => 'Oman';
+
+  @override
+  String get countryCodePA => 'Panama';
+
+  @override
+  String get countryCodePE => 'Peru';
+
+  @override
+  String get countryCodePF => 'French Polynesia';
+
+  @override
+  String get countryCodePG => 'Papua New Guinea';
+
+  @override
+  String get countryCodePH => 'Philippines';
+
+  @override
+  String get countryCodePK => 'Pakistan';
+
+  @override
+  String get countryCodePL => 'Poland';
+
+  @override
+  String get countryCodePM => 'Saint Pierre and Miquelon';
+
+  @override
+  String get countryCodePN => 'Pitcairn';
+
+  @override
+  String get countryCodePR => 'Puerto Rico';
+
+  @override
+  String get countryCodePS => 'Palestine, State of';
+
+  @override
+  String get countryCodePT => 'Portugal';
+
+  @override
+  String get countryCodePW => 'Palau';
+
+  @override
+  String get countryCodePY => 'Paraguay';
+
+  @override
+  String get countryCodeQA => 'Qatar';
+
+  @override
+  String get countryCodeRE => 'Réunion';
+
+  @override
+  String get countryCodeRO => 'Romania';
+
+  @override
+  String get countryCodeRS => 'Serbia';
+
+  @override
+  String get countryCodeRU => 'Russian Federation';
+
+  @override
+  String get countryCodeRW => 'Rwanda';
+
+  @override
+  String get countryCodeSA => 'Saudi Arabia';
+
+  @override
+  String get countryCodeSB => 'Solomon Islands';
+
+  @override
+  String get countryCodeSC => 'Seychelles';
+
+  @override
+  String get countryCodeSD => 'Sudan';
+
+  @override
+  String get countryCodeSE => 'Sweden';
+
+  @override
+  String get countryCodeSG => 'Singapore';
+
+  @override
+  String get countryCodeSH => 'Saint Helena Ascension Tristan da Cunha';
+
+  @override
+  String get countryCodeSI => 'Slovenia';
+
+  @override
+  String get countryCodeSJ => 'Svalbard and Jan Mayen';
+
+  @override
+  String get countryCodeSK => 'Slovakia';
+
+  @override
+  String get countryCodeSL => 'Sierra Leone';
+
+  @override
+  String get countryCodeSM => 'San Marino';
+
+  @override
+  String get countryCodeSN => 'Senegal';
+
+  @override
+  String get countryCodeSO => 'Somalia';
+
+  @override
+  String get countryCodeSR => 'Suriname';
+
+  @override
+  String get countryCodeSS => 'South Sudan';
+
+  @override
+  String get countryCodeST => 'Sao Tome and Principe';
+
+  @override
+  String get countryCodeSV => 'El Salvador';
+
+  @override
+  String get countryCodeSX => 'Sint Maarten (Dutch part)';
+
+  @override
+  String get countryCodeSY => 'Syrian Arab Republic';
+
+  @override
+  String get countryCodeSZ => 'Eswatini';
+
+  @override
+  String get countryCodeTC => 'Turks and Caicos Islands';
+
+  @override
+  String get countryCodeTD => 'Chad';
+
+  @override
+  String get countryCodeTF => 'French Southern Territories';
+
+  @override
+  String get countryCodeTG => 'Togo';
+
+  @override
+  String get countryCodeTH => 'Thailand';
+
+  @override
+  String get countryCodeTJ => 'Tajikistan';
+
+  @override
+  String get countryCodeTK => 'Tokelau';
+
+  @override
+  String get countryCodeTL => 'Timor-Leste';
+
+  @override
+  String get countryCodeTM => 'Turkmenistan';
+
+  @override
+  String get countryCodeTN => 'Tunisia';
+
+  @override
+  String get countryCodeTO => 'Tonga';
+
+  @override
+  String get countryCodeTR => 'Turkey';
+
+  @override
+  String get countryCodeTT => 'Trinidad and Tobago';
+
+  @override
+  String get countryCodeTV => 'Tuvalu';
+
+  @override
+  String get countryCodeTW => 'Taiwan, Province of China';
+
+  @override
+  String get countryCodeTZ => 'Tanzania, United Republic of';
+
+  @override
+  String get countryCodeUA => 'Ukraine';
+
+  @override
+  String get countryCodeUG => 'Uganda';
+
+  @override
+  String get countryCodeUM => 'United States Minor Outlying Islands';
+
+  @override
+  String get countryCodeUS => 'United States of America';
+
+  @override
+  String get countryCodeUY => 'Uruguay';
+
+  @override
+  String get countryCodeUZ => 'Uzbekistan';
+
+  @override
+  String get countryCodeVA => 'Holy See';
+
+  @override
+  String get countryCodeVC => 'Saint Vincent and the Grenadines';
+
+  @override
+  String get countryCodeVE => 'Venezuela (Bolivarian Republic of)';
+
+  @override
+  String get countryCodeVG => 'Virgin Islands (British)';
+
+  @override
+  String get countryCodeVI => 'Virgin Islands (U.S.)';
+
+  @override
+  String get countryCodeVN => 'Viet Nam';
+
+  @override
+  String get countryCodeVU => 'Vanuatu';
+
+  @override
+  String get countryCodeWF => 'Wallis and Futuna';
+
+  @override
+  String get countryCodeWS => 'Samoa';
+
+  @override
+  String get countryCodeYE => 'Yemen';
+
+  @override
+  String get countryCodeYT => 'Mayotte';
+
+  @override
+  String get countryCodeZA => 'South Africa';
+
+  @override
+  String get countryCodeZM => 'Zambia';
+
+  @override
+  String get countryCodeZW => 'Zimbabwe';
 }

--- a/lib/src/ui/screens/checkup/steps/location.dart
+++ b/lib/src/ui/screens/checkup/steps/location.dart
@@ -1,7 +1,3 @@
-import 'package:covidnearme/src/app.dart';
-import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
-import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
-import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,6 +5,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:covidnearme/src/blocs/checkup/checkup.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:covidnearme/src/ui/utils/checkups.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/country_dropdown.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
+import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
+import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
+
 import 'index.dart';
 
 class LocationStep extends StatefulWidget implements CheckupStep {
@@ -30,301 +31,6 @@ class _LocationStepState extends State<LocationStep> {
   LocalKey zipCodeKey = ValueKey<String>('ZIP Code');
   LocalKey countryKey = ValueKey<String>('Country');
 
-  Map<String, String> countryCodeToName;
-  Map<String, String> nameToCountryCode;
-  List<DropdownMenuItem<String>> _dropdownItems;
-
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    AppLocalizations localizations = AppLocalizations.of(context);
-    _updateCountryCodes(localizations);
-    _dropdownItems = _getDropdownItems(context, localizations);
-  }
-
-  void _updateCountryCodes(AppLocalizations localizations) {
-    countryCodeToName = <String, String>{
-      'AD': localizations.countryCodeAD,
-      'AE': localizations.countryCodeAE,
-      'AF': localizations.countryCodeAF,
-      'AG': localizations.countryCodeAG,
-      'AI': localizations.countryCodeAI,
-      'AL': localizations.countryCodeAL,
-      'AM': localizations.countryCodeAM,
-      'AO': localizations.countryCodeAO,
-      'AQ': localizations.countryCodeAQ,
-      'AR': localizations.countryCodeAR,
-      'AS': localizations.countryCodeAS,
-      'AT': localizations.countryCodeAT,
-      'AU': localizations.countryCodeAU,
-      'AW': localizations.countryCodeAW,
-      'AX': localizations.countryCodeAX,
-      'AZ': localizations.countryCodeAZ,
-      'BA': localizations.countryCodeBA,
-      'BB': localizations.countryCodeBB,
-      'BD': localizations.countryCodeBD,
-      'BE': localizations.countryCodeBE,
-      'BF': localizations.countryCodeBF,
-      'BG': localizations.countryCodeBG,
-      'BH': localizations.countryCodeBH,
-      'BI': localizations.countryCodeBI,
-      'BJ': localizations.countryCodeBJ,
-      'BL': localizations.countryCodeBL,
-      'BM': localizations.countryCodeBM,
-      'BN': localizations.countryCodeBN,
-      'BO': localizations.countryCodeBO,
-      'BQ': localizations.countryCodeBQ,
-      'BR': localizations.countryCodeBR,
-      'BS': localizations.countryCodeBS,
-      'BT': localizations.countryCodeBT,
-      'BV': localizations.countryCodeBV,
-      'BW': localizations.countryCodeBW,
-      'BY': localizations.countryCodeBY,
-      'BZ': localizations.countryCodeBZ,
-      'CA': localizations.countryCodeCA,
-      'CC': localizations.countryCodeCC,
-      'CD': localizations.countryCodeCD,
-      'CF': localizations.countryCodeCF,
-      'CG': localizations.countryCodeCG,
-      'CH': localizations.countryCodeCH,
-      'CI': localizations.countryCodeCI,
-      'CK': localizations.countryCodeCK,
-      'CL': localizations.countryCodeCL,
-      'CM': localizations.countryCodeCM,
-      'CN': localizations.countryCodeCN,
-      'CO': localizations.countryCodeCO,
-      'CR': localizations.countryCodeCR,
-      'CU': localizations.countryCodeCU,
-      'CV': localizations.countryCodeCV,
-      'CW': localizations.countryCodeCW,
-      'CX': localizations.countryCodeCX,
-      'CY': localizations.countryCodeCY,
-      'CZ': localizations.countryCodeCZ,
-      'DE': localizations.countryCodeDE,
-      'DJ': localizations.countryCodeDJ,
-      'DK': localizations.countryCodeDK,
-      'DM': localizations.countryCodeDM,
-      'DO': localizations.countryCodeDO,
-      'DZ': localizations.countryCodeDZ,
-      'EC': localizations.countryCodeEC,
-      'EE': localizations.countryCodeEE,
-      'EG': localizations.countryCodeEG,
-      'EH': localizations.countryCodeEH,
-      'ER': localizations.countryCodeER,
-      'ES': localizations.countryCodeES,
-      'ET': localizations.countryCodeET,
-      'FI': localizations.countryCodeFI,
-      'FJ': localizations.countryCodeFJ,
-      'FK': localizations.countryCodeFK,
-      'FM': localizations.countryCodeFM,
-      'FO': localizations.countryCodeFO,
-      'FR': localizations.countryCodeFR,
-      'GA': localizations.countryCodeGA,
-      'GB': localizations.countryCodeGB,
-      'GD': localizations.countryCodeGD,
-      'GE': localizations.countryCodeGE,
-      'GF': localizations.countryCodeGF,
-      'GG': localizations.countryCodeGG,
-      'GH': localizations.countryCodeGH,
-      'GI': localizations.countryCodeGI,
-      'GL': localizations.countryCodeGL,
-      'GM': localizations.countryCodeGM,
-      'GN': localizations.countryCodeGN,
-      'GP': localizations.countryCodeGP,
-      'GQ': localizations.countryCodeGQ,
-      'GR': localizations.countryCodeGR,
-      'GS': localizations.countryCodeGS,
-      'GT': localizations.countryCodeGT,
-      'GU': localizations.countryCodeGU,
-      'GW': localizations.countryCodeGW,
-      'GY': localizations.countryCodeGY,
-      'HK': localizations.countryCodeHK,
-      'HM': localizations.countryCodeHM,
-      'HN': localizations.countryCodeHN,
-      'HR': localizations.countryCodeHR,
-      'HT': localizations.countryCodeHT,
-      'HU': localizations.countryCodeHU,
-      'ID': localizations.countryCodeID,
-      'IE': localizations.countryCodeIE,
-      'IL': localizations.countryCodeIL,
-      'IM': localizations.countryCodeIM,
-      'IN': localizations.countryCodeIN,
-      'IO': localizations.countryCodeIO,
-      'IQ': localizations.countryCodeIQ,
-      'IR': localizations.countryCodeIR,
-      'IS': localizations.countryCodeIS,
-      'IT': localizations.countryCodeIT,
-      'JE': localizations.countryCodeJE,
-      'JM': localizations.countryCodeJM,
-      'JO': localizations.countryCodeJO,
-      'JP': localizations.countryCodeJP,
-      'KE': localizations.countryCodeKE,
-      'KG': localizations.countryCodeKG,
-      'KH': localizations.countryCodeKH,
-      'KI': localizations.countryCodeKI,
-      'KM': localizations.countryCodeKM,
-      'KN': localizations.countryCodeKN,
-      'KP': localizations.countryCodeKP,
-      'KR': localizations.countryCodeKR,
-      'KW': localizations.countryCodeKW,
-      'KY': localizations.countryCodeKY,
-      'KZ': localizations.countryCodeKZ,
-      'LA': localizations.countryCodeLA,
-      'LB': localizations.countryCodeLB,
-      'LC': localizations.countryCodeLC,
-      'LI': localizations.countryCodeLI,
-      'LK': localizations.countryCodeLK,
-      'LR': localizations.countryCodeLR,
-      'LS': localizations.countryCodeLS,
-      'LT': localizations.countryCodeLT,
-      'LU': localizations.countryCodeLU,
-      'LV': localizations.countryCodeLV,
-      'LY': localizations.countryCodeLY,
-      'MA': localizations.countryCodeMA,
-      'MC': localizations.countryCodeMC,
-      'MD': localizations.countryCodeMD,
-      'ME': localizations.countryCodeME,
-      'MF': localizations.countryCodeMF,
-      'MG': localizations.countryCodeMG,
-      'MH': localizations.countryCodeMH,
-      'MK': localizations.countryCodeMK,
-      'ML': localizations.countryCodeML,
-      'MM': localizations.countryCodeMM,
-      'MN': localizations.countryCodeMN,
-      'MO': localizations.countryCodeMO,
-      'MP': localizations.countryCodeMP,
-      'MQ': localizations.countryCodeMQ,
-      'MR': localizations.countryCodeMR,
-      'MS': localizations.countryCodeMS,
-      'MT': localizations.countryCodeMT,
-      'MU': localizations.countryCodeMU,
-      'MV': localizations.countryCodeMV,
-      'MW': localizations.countryCodeMW,
-      'MX': localizations.countryCodeMX,
-      'MY': localizations.countryCodeMY,
-      'MZ': localizations.countryCodeMZ,
-      'NA': localizations.countryCodeNA,
-      'NC': localizations.countryCodeNC,
-      'NE': localizations.countryCodeNE,
-      'NF': localizations.countryCodeNF,
-      'NG': localizations.countryCodeNG,
-      'NI': localizations.countryCodeNI,
-      'NL': localizations.countryCodeNL,
-      'NO': localizations.countryCodeNO,
-      'NP': localizations.countryCodeNP,
-      'NR': localizations.countryCodeNR,
-      'NU': localizations.countryCodeNU,
-      'NZ': localizations.countryCodeNZ,
-      'OM': localizations.countryCodeOM,
-      'PA': localizations.countryCodePA,
-      'PE': localizations.countryCodePE,
-      'PF': localizations.countryCodePF,
-      'PG': localizations.countryCodePG,
-      'PH': localizations.countryCodePH,
-      'PK': localizations.countryCodePK,
-      'PL': localizations.countryCodePL,
-      'PM': localizations.countryCodePM,
-      'PN': localizations.countryCodePN,
-      'PR': localizations.countryCodePR,
-      'PS': localizations.countryCodePS,
-      'PT': localizations.countryCodePT,
-      'PW': localizations.countryCodePW,
-      'PY': localizations.countryCodePY,
-      'QA': localizations.countryCodeQA,
-      'RE': localizations.countryCodeRE,
-      'RO': localizations.countryCodeRO,
-      'RS': localizations.countryCodeRS,
-      'RU': localizations.countryCodeRU,
-      'RW': localizations.countryCodeRW,
-      'SA': localizations.countryCodeSA,
-      'SB': localizations.countryCodeSB,
-      'SC': localizations.countryCodeSC,
-      'SD': localizations.countryCodeSD,
-      'SE': localizations.countryCodeSE,
-      'SG': localizations.countryCodeSG,
-      'SH': localizations.countryCodeSH,
-      'SI': localizations.countryCodeSI,
-      'SJ': localizations.countryCodeSJ,
-      'SK': localizations.countryCodeSK,
-      'SL': localizations.countryCodeSL,
-      'SM': localizations.countryCodeSM,
-      'SN': localizations.countryCodeSN,
-      'SO': localizations.countryCodeSO,
-      'SR': localizations.countryCodeSR,
-      'SS': localizations.countryCodeSS,
-      'ST': localizations.countryCodeST,
-      'SV': localizations.countryCodeSV,
-      'SX': localizations.countryCodeSX,
-      'SY': localizations.countryCodeSY,
-      'SZ': localizations.countryCodeSZ,
-      'TC': localizations.countryCodeTC,
-      'TD': localizations.countryCodeTD,
-      'TF': localizations.countryCodeTF,
-      'TG': localizations.countryCodeTG,
-      'TH': localizations.countryCodeTH,
-      'TJ': localizations.countryCodeTJ,
-      'TK': localizations.countryCodeTK,
-      'TL': localizations.countryCodeTL,
-      'TM': localizations.countryCodeTM,
-      'TN': localizations.countryCodeTN,
-      'TO': localizations.countryCodeTO,
-      'TR': localizations.countryCodeTR,
-      'TT': localizations.countryCodeTT,
-      'TV': localizations.countryCodeTV,
-      'TW': localizations.countryCodeTW,
-      'TZ': localizations.countryCodeTZ,
-      'UA': localizations.countryCodeUA,
-      'UG': localizations.countryCodeUG,
-      'UM': localizations.countryCodeUM,
-      'UY': localizations.countryCodeUY,
-      'UZ': localizations.countryCodeUZ,
-      'VA': localizations.countryCodeVA,
-      'VC': localizations.countryCodeVC,
-      'VE': localizations.countryCodeVE,
-      'VG': localizations.countryCodeVG,
-      'VI': localizations.countryCodeVI,
-      'VN': localizations.countryCodeVN,
-      'VU': localizations.countryCodeVU,
-      'WF': localizations.countryCodeWF,
-      'WS': localizations.countryCodeWS,
-      'YE': localizations.countryCodeYE,
-      'YT': localizations.countryCodeYT,
-      'ZA': localizations.countryCodeZA,
-      'ZM': localizations.countryCodeZM,
-      'ZW': localizations.countryCodeZW,
-    };
-    nameToCountryCode = <String, String>{};
-    for (final String code in countryCodeToName.keys) {
-      nameToCountryCode[countryCodeToName[code]] = code;
-    }
-  }
-
-  List<DropdownMenuItem<String>> _getDropdownItems(
-      BuildContext context, AppLocalizations localizations) {
-    final List<String> countries = nameToCountryCode.keys.toList();
-    countries.sort();
-    final List<DropdownMenuItem<String>> result = countries
-        .map<DropdownMenuItem<String>>(
-          (String country) => DropdownMenuItem<String>(
-        child: Text(country),
-        value: nameToCountryCode[country],
-      ),
-    )
-        .toList();
-
-    // Add the "No selection" selection.
-    result.insert(
-      0,
-      DropdownMenuItem<String>(
-        child: Text(localizations.locationStepNoCountrySelected,
-            style: Theme.of(context).textTheme.button.copyWith(
-              fontStyle: FontStyle.italic,
-            )),
-        value: 'None',
-      ),
-    );
-    return result;
-  }
-
   String _validateZipCode(String value, [AppLocalizations localizations]) {
     if (value != '') {
       final int zipValue = int.tryParse(value, radix: 10);
@@ -338,7 +44,9 @@ class _LocationStepState extends State<LocationStep> {
   bool _updateValidity() {
     bool valid = false;
     if (_isUSA) {
-      valid = _displayedZip != null && _displayedZip.isNotEmpty && _validateZipCode(_displayedZip) == null;
+      valid = _displayedZip != null &&
+          _displayedZip.isNotEmpty &&
+          _validateZipCode(_displayedZip) == null;
       if (_zipIsValid != valid) {
         setState(() {
           _zipIsValid = valid;
@@ -416,15 +124,14 @@ class _LocationStepState extends State<LocationStep> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
-    if (countryCodeToName == null) {
-      _updateCountryCodes(localizations);
-    }
     return BlocBuilder<CheckupBloc, CheckupState>(
       builder: (context, state) {
         final CheckupStateInProgress checkupState = state;
         final CheckupLocation existingResponse = checkupState.checkup.location;
-        _displayedZip ??= existingResponse != null ? existingResponse.zipCode : '';
-        _displayedCountry ??= existingResponse != null ? existingResponse.country : '';
+        _displayedZip ??=
+            existingResponse != null ? existingResponse.zipCode : '';
+        _displayedCountry ??=
+            existingResponse != null ? existingResponse.country : '';
         return ScrollableBody(
           child: Container(
             color: Theme.of(context).backgroundColor,
@@ -432,46 +139,45 @@ class _LocationStepState extends State<LocationStep> {
               padding: const EdgeInsets.symmetric(horizontal: 40),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  Padding(
-                    padding: EdgeInsets.only(bottom: 20),
-                    child: Text(
-                      localizations.locationStepTitle,
-                      style: Theme.of(context).textTheme.title.copyWith(
-                            fontSize: 26,
-                          ),
-                      textAlign: TextAlign.center,
+                  Center(
+                    child: Padding(
+                      padding: EdgeInsets.only(bottom: 20),
+                      child: Text(
+                        localizations.locationStepTitle,
+                        style: Theme.of(context).textTheme.title.copyWith(
+                              fontSize: 26,
+                            ),
+                        textAlign: TextAlign.center,
+                      ),
                     ),
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 20.0),
-                    child: Column(
-                      children: <Widget>[
-                        _LabeledRadio<bool>(
-                          onTap: () {
-                            setState(() {
-                              _isUSA = true;
-                              _updateValidity();
-                            });
-                          },
-                          value: true,
-                          groupValue: _isUSA,
-                          label: localizations.locationStepInUSA,
-                        ),
-                        _LabeledRadio<bool>(
-                          onTap: () {
-                            setState(() {
-                              _isUSA = false;
-                              _updateValidity();
-                            });
-                          },
-                          value: false,
-                          groupValue: _isUSA,
-                          label: localizations.locationStepAnotherCountry,
-                        ),
-                      ],
-                    ),
+                  Column(
+                    children: <Widget>[
+                      _LabeledRadio<bool>(
+                        onTap: () {
+                          setState(() {
+                            _isUSA = true;
+                            _updateValidity();
+                          });
+                        },
+                        value: true,
+                        groupValue: _isUSA,
+                        label: localizations.locationStepInUSA,
+                      ),
+                      _LabeledRadio<bool>(
+                        onTap: () {
+                          setState(() {
+                            _isUSA = false;
+                            _updateValidity();
+                          });
+                        },
+                        value: false,
+                        groupValue: _isUSA,
+                        label: localizations.locationStepAnotherCountry,
+                      ),
+                    ],
                   ),
                   if (_isUSA)
                     EntryField(
@@ -483,24 +189,24 @@ class _LocationStepState extends State<LocationStep> {
                         localizations: localizations,
                       ),
                       label: localizations.locationStepZipCode,
-                      keyboardType: TextInputType.numberWithOptions(decimal: false, signed: false),
-                      validator: (String string) => _validateZipCode(string, localizations),
+                      keyboardType: TextInputType.numberWithOptions(
+                          decimal: false, signed: false),
+                      validator: (String string) =>
+                          _validateZipCode(string, localizations),
                     ),
                   if (!_isUSA)
-                    DropdownButton(
-                      key: countryKey,
+                    CountryDropdown(
                       onChanged: (String value) => _updateCountry(
                         countryCode: value,
                         checkupState: checkupState,
                         localizations: localizations,
                       ),
-                      items: _dropdownItems,
-                      style: Theme.of(context).textTheme.button,
                       value: _displayedCountry,
                     ),
                   StepFinishedButton(
                     isLastStep: false,
-                    validated: (_isUSA && _zipIsValid) || (!_isUSA && _countryIsValid),
+                    validated:
+                        (_isUSA && _zipIsValid) || (!_isUSA && _countryIsValid),
                   ),
                 ],
               ),
@@ -532,6 +238,7 @@ class _LabeledRadio<T> extends StatelessWidget {
         Radio<T>(
           onChanged: (T value) => onTap(),
           value: value,
+          activeColor: Theme.of(context).colorScheme.secondary,
           groupValue: groupValue,
         ),
         GestureDetector(

--- a/lib/src/ui/screens/checkup/steps/location.dart
+++ b/lib/src/ui/screens/checkup/steps/location.dart
@@ -1,3 +1,4 @@
+import 'package:covidnearme/src/app.dart';
 import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
 import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
@@ -24,10 +25,305 @@ class _LocationStepState extends State<LocationStep> {
   // Keep the values entered, so that when switching between modes,
   // they stick, but we don't have to update the preferences values.
   String _displayedZip;
-  String _displayedCountry;
+  String _displayedCountry = 'None';
 
   LocalKey zipCodeKey = ValueKey<String>('ZIP Code');
   LocalKey countryKey = ValueKey<String>('Country');
+
+  Map<String, String> countryCodeToName;
+  Map<String, String> nameToCountryCode;
+  List<DropdownMenuItem<String>> _dropdownItems;
+
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    AppLocalizations localizations = AppLocalizations.of(context);
+    _updateCountryCodes(localizations);
+    _dropdownItems = _getDropdownItems(context, localizations);
+  }
+
+  void _updateCountryCodes(AppLocalizations localizations) {
+    countryCodeToName = <String, String>{
+      'AD': localizations.countryCodeAD,
+      'AE': localizations.countryCodeAE,
+      'AF': localizations.countryCodeAF,
+      'AG': localizations.countryCodeAG,
+      'AI': localizations.countryCodeAI,
+      'AL': localizations.countryCodeAL,
+      'AM': localizations.countryCodeAM,
+      'AO': localizations.countryCodeAO,
+      'AQ': localizations.countryCodeAQ,
+      'AR': localizations.countryCodeAR,
+      'AS': localizations.countryCodeAS,
+      'AT': localizations.countryCodeAT,
+      'AU': localizations.countryCodeAU,
+      'AW': localizations.countryCodeAW,
+      'AX': localizations.countryCodeAX,
+      'AZ': localizations.countryCodeAZ,
+      'BA': localizations.countryCodeBA,
+      'BB': localizations.countryCodeBB,
+      'BD': localizations.countryCodeBD,
+      'BE': localizations.countryCodeBE,
+      'BF': localizations.countryCodeBF,
+      'BG': localizations.countryCodeBG,
+      'BH': localizations.countryCodeBH,
+      'BI': localizations.countryCodeBI,
+      'BJ': localizations.countryCodeBJ,
+      'BL': localizations.countryCodeBL,
+      'BM': localizations.countryCodeBM,
+      'BN': localizations.countryCodeBN,
+      'BO': localizations.countryCodeBO,
+      'BQ': localizations.countryCodeBQ,
+      'BR': localizations.countryCodeBR,
+      'BS': localizations.countryCodeBS,
+      'BT': localizations.countryCodeBT,
+      'BV': localizations.countryCodeBV,
+      'BW': localizations.countryCodeBW,
+      'BY': localizations.countryCodeBY,
+      'BZ': localizations.countryCodeBZ,
+      'CA': localizations.countryCodeCA,
+      'CC': localizations.countryCodeCC,
+      'CD': localizations.countryCodeCD,
+      'CF': localizations.countryCodeCF,
+      'CG': localizations.countryCodeCG,
+      'CH': localizations.countryCodeCH,
+      'CI': localizations.countryCodeCI,
+      'CK': localizations.countryCodeCK,
+      'CL': localizations.countryCodeCL,
+      'CM': localizations.countryCodeCM,
+      'CN': localizations.countryCodeCN,
+      'CO': localizations.countryCodeCO,
+      'CR': localizations.countryCodeCR,
+      'CU': localizations.countryCodeCU,
+      'CV': localizations.countryCodeCV,
+      'CW': localizations.countryCodeCW,
+      'CX': localizations.countryCodeCX,
+      'CY': localizations.countryCodeCY,
+      'CZ': localizations.countryCodeCZ,
+      'DE': localizations.countryCodeDE,
+      'DJ': localizations.countryCodeDJ,
+      'DK': localizations.countryCodeDK,
+      'DM': localizations.countryCodeDM,
+      'DO': localizations.countryCodeDO,
+      'DZ': localizations.countryCodeDZ,
+      'EC': localizations.countryCodeEC,
+      'EE': localizations.countryCodeEE,
+      'EG': localizations.countryCodeEG,
+      'EH': localizations.countryCodeEH,
+      'ER': localizations.countryCodeER,
+      'ES': localizations.countryCodeES,
+      'ET': localizations.countryCodeET,
+      'FI': localizations.countryCodeFI,
+      'FJ': localizations.countryCodeFJ,
+      'FK': localizations.countryCodeFK,
+      'FM': localizations.countryCodeFM,
+      'FO': localizations.countryCodeFO,
+      'FR': localizations.countryCodeFR,
+      'GA': localizations.countryCodeGA,
+      'GB': localizations.countryCodeGB,
+      'GD': localizations.countryCodeGD,
+      'GE': localizations.countryCodeGE,
+      'GF': localizations.countryCodeGF,
+      'GG': localizations.countryCodeGG,
+      'GH': localizations.countryCodeGH,
+      'GI': localizations.countryCodeGI,
+      'GL': localizations.countryCodeGL,
+      'GM': localizations.countryCodeGM,
+      'GN': localizations.countryCodeGN,
+      'GP': localizations.countryCodeGP,
+      'GQ': localizations.countryCodeGQ,
+      'GR': localizations.countryCodeGR,
+      'GS': localizations.countryCodeGS,
+      'GT': localizations.countryCodeGT,
+      'GU': localizations.countryCodeGU,
+      'GW': localizations.countryCodeGW,
+      'GY': localizations.countryCodeGY,
+      'HK': localizations.countryCodeHK,
+      'HM': localizations.countryCodeHM,
+      'HN': localizations.countryCodeHN,
+      'HR': localizations.countryCodeHR,
+      'HT': localizations.countryCodeHT,
+      'HU': localizations.countryCodeHU,
+      'ID': localizations.countryCodeID,
+      'IE': localizations.countryCodeIE,
+      'IL': localizations.countryCodeIL,
+      'IM': localizations.countryCodeIM,
+      'IN': localizations.countryCodeIN,
+      'IO': localizations.countryCodeIO,
+      'IQ': localizations.countryCodeIQ,
+      'IR': localizations.countryCodeIR,
+      'IS': localizations.countryCodeIS,
+      'IT': localizations.countryCodeIT,
+      'JE': localizations.countryCodeJE,
+      'JM': localizations.countryCodeJM,
+      'JO': localizations.countryCodeJO,
+      'JP': localizations.countryCodeJP,
+      'KE': localizations.countryCodeKE,
+      'KG': localizations.countryCodeKG,
+      'KH': localizations.countryCodeKH,
+      'KI': localizations.countryCodeKI,
+      'KM': localizations.countryCodeKM,
+      'KN': localizations.countryCodeKN,
+      'KP': localizations.countryCodeKP,
+      'KR': localizations.countryCodeKR,
+      'KW': localizations.countryCodeKW,
+      'KY': localizations.countryCodeKY,
+      'KZ': localizations.countryCodeKZ,
+      'LA': localizations.countryCodeLA,
+      'LB': localizations.countryCodeLB,
+      'LC': localizations.countryCodeLC,
+      'LI': localizations.countryCodeLI,
+      'LK': localizations.countryCodeLK,
+      'LR': localizations.countryCodeLR,
+      'LS': localizations.countryCodeLS,
+      'LT': localizations.countryCodeLT,
+      'LU': localizations.countryCodeLU,
+      'LV': localizations.countryCodeLV,
+      'LY': localizations.countryCodeLY,
+      'MA': localizations.countryCodeMA,
+      'MC': localizations.countryCodeMC,
+      'MD': localizations.countryCodeMD,
+      'ME': localizations.countryCodeME,
+      'MF': localizations.countryCodeMF,
+      'MG': localizations.countryCodeMG,
+      'MH': localizations.countryCodeMH,
+      'MK': localizations.countryCodeMK,
+      'ML': localizations.countryCodeML,
+      'MM': localizations.countryCodeMM,
+      'MN': localizations.countryCodeMN,
+      'MO': localizations.countryCodeMO,
+      'MP': localizations.countryCodeMP,
+      'MQ': localizations.countryCodeMQ,
+      'MR': localizations.countryCodeMR,
+      'MS': localizations.countryCodeMS,
+      'MT': localizations.countryCodeMT,
+      'MU': localizations.countryCodeMU,
+      'MV': localizations.countryCodeMV,
+      'MW': localizations.countryCodeMW,
+      'MX': localizations.countryCodeMX,
+      'MY': localizations.countryCodeMY,
+      'MZ': localizations.countryCodeMZ,
+      'NA': localizations.countryCodeNA,
+      'NC': localizations.countryCodeNC,
+      'NE': localizations.countryCodeNE,
+      'NF': localizations.countryCodeNF,
+      'NG': localizations.countryCodeNG,
+      'NI': localizations.countryCodeNI,
+      'NL': localizations.countryCodeNL,
+      'NO': localizations.countryCodeNO,
+      'NP': localizations.countryCodeNP,
+      'NR': localizations.countryCodeNR,
+      'NU': localizations.countryCodeNU,
+      'NZ': localizations.countryCodeNZ,
+      'OM': localizations.countryCodeOM,
+      'PA': localizations.countryCodePA,
+      'PE': localizations.countryCodePE,
+      'PF': localizations.countryCodePF,
+      'PG': localizations.countryCodePG,
+      'PH': localizations.countryCodePH,
+      'PK': localizations.countryCodePK,
+      'PL': localizations.countryCodePL,
+      'PM': localizations.countryCodePM,
+      'PN': localizations.countryCodePN,
+      'PR': localizations.countryCodePR,
+      'PS': localizations.countryCodePS,
+      'PT': localizations.countryCodePT,
+      'PW': localizations.countryCodePW,
+      'PY': localizations.countryCodePY,
+      'QA': localizations.countryCodeQA,
+      'RE': localizations.countryCodeRE,
+      'RO': localizations.countryCodeRO,
+      'RS': localizations.countryCodeRS,
+      'RU': localizations.countryCodeRU,
+      'RW': localizations.countryCodeRW,
+      'SA': localizations.countryCodeSA,
+      'SB': localizations.countryCodeSB,
+      'SC': localizations.countryCodeSC,
+      'SD': localizations.countryCodeSD,
+      'SE': localizations.countryCodeSE,
+      'SG': localizations.countryCodeSG,
+      'SH': localizations.countryCodeSH,
+      'SI': localizations.countryCodeSI,
+      'SJ': localizations.countryCodeSJ,
+      'SK': localizations.countryCodeSK,
+      'SL': localizations.countryCodeSL,
+      'SM': localizations.countryCodeSM,
+      'SN': localizations.countryCodeSN,
+      'SO': localizations.countryCodeSO,
+      'SR': localizations.countryCodeSR,
+      'SS': localizations.countryCodeSS,
+      'ST': localizations.countryCodeST,
+      'SV': localizations.countryCodeSV,
+      'SX': localizations.countryCodeSX,
+      'SY': localizations.countryCodeSY,
+      'SZ': localizations.countryCodeSZ,
+      'TC': localizations.countryCodeTC,
+      'TD': localizations.countryCodeTD,
+      'TF': localizations.countryCodeTF,
+      'TG': localizations.countryCodeTG,
+      'TH': localizations.countryCodeTH,
+      'TJ': localizations.countryCodeTJ,
+      'TK': localizations.countryCodeTK,
+      'TL': localizations.countryCodeTL,
+      'TM': localizations.countryCodeTM,
+      'TN': localizations.countryCodeTN,
+      'TO': localizations.countryCodeTO,
+      'TR': localizations.countryCodeTR,
+      'TT': localizations.countryCodeTT,
+      'TV': localizations.countryCodeTV,
+      'TW': localizations.countryCodeTW,
+      'TZ': localizations.countryCodeTZ,
+      'UA': localizations.countryCodeUA,
+      'UG': localizations.countryCodeUG,
+      'UM': localizations.countryCodeUM,
+      'UY': localizations.countryCodeUY,
+      'UZ': localizations.countryCodeUZ,
+      'VA': localizations.countryCodeVA,
+      'VC': localizations.countryCodeVC,
+      'VE': localizations.countryCodeVE,
+      'VG': localizations.countryCodeVG,
+      'VI': localizations.countryCodeVI,
+      'VN': localizations.countryCodeVN,
+      'VU': localizations.countryCodeVU,
+      'WF': localizations.countryCodeWF,
+      'WS': localizations.countryCodeWS,
+      'YE': localizations.countryCodeYE,
+      'YT': localizations.countryCodeYT,
+      'ZA': localizations.countryCodeZA,
+      'ZM': localizations.countryCodeZM,
+      'ZW': localizations.countryCodeZW,
+    };
+    nameToCountryCode = <String, String>{};
+    for (final String code in countryCodeToName.keys) {
+      nameToCountryCode[countryCodeToName[code]] = code;
+    }
+  }
+
+  List<DropdownMenuItem<String>> _getDropdownItems(
+      BuildContext context, AppLocalizations localizations) {
+    final List<String> countries = nameToCountryCode.keys.toList();
+    countries.sort();
+    final List<DropdownMenuItem<String>> result = countries
+        .map<DropdownMenuItem<String>>(
+          (String country) => DropdownMenuItem<String>(
+        child: Text(country),
+        value: nameToCountryCode[country],
+      ),
+    )
+        .toList();
+
+    // Add the "No selection" selection.
+    result.insert(
+      0,
+      DropdownMenuItem<String>(
+        child: Text(localizations.locationStepNoCountrySelected,
+            style: Theme.of(context).textTheme.button.copyWith(
+              fontStyle: FontStyle.italic,
+            )),
+        value: 'None',
+      ),
+    );
+    return result;
+  }
 
   String _validateZipCode(String value, [AppLocalizations localizations]) {
     if (value != '') {
@@ -39,34 +335,17 @@ class _LocationStepState extends State<LocationStep> {
     return null;
   }
 
-  String _validateCountry(String value, [AppLocalizations localizations]) {
-    if (value != '') {
-      final RegExp validChars = RegExp(
-        r'''^[^\d\n\t\r\[\]{}'";:/?,\\|<>@#$%^&*()_+=`~]*$''',
-        unicode: true,
-      );
-      if (!validChars.hasMatch(value) && value.trim().isNotEmpty) {
-        return localizations?.locationStepInvalidCountry ?? '';
-      }
-    }
-    return null;
-  }
-
-  bool _updateValidity(String zipCode, String country) {
-    bool valid;
+  bool _updateValidity() {
+    bool valid = false;
     if (_isUSA) {
-      valid = zipCode != null &&
-          zipCode.isNotEmpty &&
-          _validateZipCode(zipCode) == null;
+      valid = _displayedZip != null && _displayedZip.isNotEmpty && _validateZipCode(_displayedZip) == null;
       if (_zipIsValid != valid) {
         setState(() {
           _zipIsValid = valid;
         });
       }
     } else {
-      valid = country != null &&
-          country.isNotEmpty &&
-          _validateCountry(country) == null;
+      valid = _displayedCountry != 'None';
       if (_countryIsValid != valid) {
         setState(() {
           _countryIsValid = valid;
@@ -82,9 +361,11 @@ class _LocationStepState extends State<LocationStep> {
     @required AppLocalizations localizations,
   }) {
     assert(zipCode != null);
-    _displayedZip = zipCode;
+    setState(() {
+      _displayedZip = zipCode;
+    });
     // Validate before saving.
-    if (!_updateValidity(zipCode, null)) {
+    if (!_updateValidity()) {
       return;
     }
 
@@ -94,7 +375,7 @@ class _LocationStepState extends State<LocationStep> {
       updateFunction: (Checkup checkup) {
         final CheckupLocation newResponse = CheckupLocation(
           zipCode: zipCode,
-          country: null,
+          country: 'US',
         );
 
         checkup.location = newResponse;
@@ -104,14 +385,16 @@ class _LocationStepState extends State<LocationStep> {
   }
 
   void _updateCountry({
-    String country,
+    String countryCode,
     @required CheckupStateInProgress checkupState,
     @required AppLocalizations localizations,
   }) {
-    assert(country != null);
-    _displayedCountry = country;
+    assert(countryCode != null);
+    setState(() {
+      _displayedCountry = countryCode;
+    });
     // Validate before saving.
-    if (!_updateValidity(null, country)) {
+    if (!_updateValidity()) {
       return;
     }
 
@@ -121,7 +404,7 @@ class _LocationStepState extends State<LocationStep> {
       updateFunction: (Checkup checkup) {
         final CheckupLocation newResponse = CheckupLocation(
           zipCode: null,
-          country: country,
+          country: countryCode,
         );
 
         checkup.location = newResponse;
@@ -133,14 +416,15 @@ class _LocationStepState extends State<LocationStep> {
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
+    if (countryCodeToName == null) {
+      _updateCountryCodes(localizations);
+    }
     return BlocBuilder<CheckupBloc, CheckupState>(
       builder: (context, state) {
         final CheckupStateInProgress checkupState = state;
         final CheckupLocation existingResponse = checkupState.checkup.location;
-        _displayedZip ??=
-            existingResponse != null ? existingResponse.zipCode : '';
-        _displayedCountry ??=
-            existingResponse != null ? existingResponse.country : '';
+        _displayedZip ??= existingResponse != null ? existingResponse.zipCode : '';
+        _displayedCountry ??= existingResponse != null ? existingResponse.country : '';
         return ScrollableBody(
           child: Container(
             color: Theme.of(context).backgroundColor,
@@ -168,7 +452,7 @@ class _LocationStepState extends State<LocationStep> {
                           onTap: () {
                             setState(() {
                               _isUSA = true;
-                              _updateValidity(_displayedZip, null);
+                              _updateValidity();
                             });
                           },
                           value: true,
@@ -179,7 +463,7 @@ class _LocationStepState extends State<LocationStep> {
                           onTap: () {
                             setState(() {
                               _isUSA = false;
-                              _updateValidity(null, _displayedCountry);
+                              _updateValidity();
                             });
                           },
                           value: false,
@@ -199,31 +483,24 @@ class _LocationStepState extends State<LocationStep> {
                         localizations: localizations,
                       ),
                       label: localizations.locationStepZipCode,
-                      keyboardType: TextInputType.numberWithOptions(
-                          decimal: false, signed: false),
-                      validator: (String string) =>
-                          _validateZipCode(string, localizations),
+                      keyboardType: TextInputType.numberWithOptions(decimal: false, signed: false),
+                      validator: (String string) => _validateZipCode(string, localizations),
                     ),
                   if (!_isUSA)
-                    EntryField(
+                    DropdownButton(
                       key: countryKey,
-                      initialValue: existingResponse != null
-                          ? existingResponse.country
-                          : '',
                       onChanged: (String value) => _updateCountry(
-                        country: value,
+                        countryCode: value,
                         checkupState: checkupState,
                         localizations: localizations,
                       ),
-                      label: localizations.locationStepCountry,
-                      keyboardType: TextInputType.text,
-                      validator: (String string) =>
-                          _validateCountry(string, localizations),
+                      items: _dropdownItems,
+                      style: Theme.of(context).textTheme.button,
+                      value: _displayedCountry,
                     ),
                   StepFinishedButton(
                     isLastStep: false,
-                    validated:
-                        (_isUSA && _zipIsValid) || (!_isUSA && _countryIsValid),
+                    validated: (_isUSA && _zipIsValid) || (!_isUSA && _countryIsValid),
                   ),
                 ],
               ),

--- a/lib/src/ui/screens/checkup/steps/temperature.dart
+++ b/lib/src/ui/screens/checkup/steps/temperature.dart
@@ -24,9 +24,12 @@ class _TemperatureStepState extends State<TemperatureStep> {
   static const double _celsiusMin = 21.1;
   static const double _fahrenheitMax = 150.0;
   static const double _fahrenheitMin = 70.0;
-  bool get _isCelsius => _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
+  bool get _isCelsius =>
+      _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
   bool get _isFahrenheit =>
-      _degrees != null && _degrees <= _fahrenheitMax && _degrees >= _fahrenheitMin;
+      _degrees != null &&
+      _degrees <= _fahrenheitMax &&
+      _degrees >= _fahrenheitMin;
   bool get _isValid => _degrees != null && (_isCelsius || _isFahrenheit);
   double _degrees;
 
@@ -103,7 +106,8 @@ class _TemperatureStepState extends State<TemperatureStep> {
           appBar: AppBar(
             title: Text(
               localizations.temperatureStepHowToDialogTitle,
-              style: theme.textTheme.headline.copyWith(color: theme.colorScheme.onBackground),
+              style: theme.textTheme.headline
+                  .copyWith(color: theme.colorScheme.onBackground),
               textAlign: TextAlign.center,
             ),
           ),
@@ -156,7 +160,8 @@ class _TemperatureStepState extends State<TemperatureStep> {
                   child: Center(
                     child: RaisedButton(
                       onPressed: () => Navigator.pop(context),
-                      child: Text(localizations.temperatureStepHowToDialogReturn),
+                      child:
+                          Text(localizations.temperatureStepHowToDialogReturn),
                     ),
                   ),
                 ),
@@ -174,7 +179,8 @@ class _TemperatureStepState extends State<TemperatureStep> {
     return BlocBuilder<CheckupBloc, CheckupState>(
       builder: (context, state) {
         final CheckupStateInProgress checkupState = state;
-        final VitalsResponse existingResponse = checkupState.checkup.vitalsResponses.firstWhere(
+        final VitalsResponse existingResponse =
+            checkupState.checkup.vitalsResponses.firstWhere(
           (VitalsResponse response) => response.id == 'temperature',
           orElse: () => null,
         );
@@ -209,16 +215,19 @@ class _TemperatureStepState extends State<TemperatureStep> {
                             initialValue: existingResponse != null
                                 ? existingResponse.response.toString()
                                 : '',
-                            onChanged: (String value) =>
-                                _updateTemperature(double.parse(value), checkupState),
-                            label: localizations.temperatureStepTemperatureLabel,
+                            onChanged: (String value) => _updateTemperature(
+                                double.parse(value), checkupState),
+                            label:
+                                localizations.temperatureStepTemperatureLabel,
                             suffix: _isValid ? (_isCelsius ? '℃' : '℉') : null,
                             keyboardType: TextInputType.number,
                             inputFormatters: [
-                              WhitelistingTextInputFormatter(RegExp(r'^\d+\.?\d?$')),
+                              WhitelistingTextInputFormatter(
+                                  RegExp(r'^\d+\.?\d?$')),
                             ],
                             autofocus: true,
-                            validator: (String value) => _validateTemperature(value, localizations),
+                            validator: (String value) =>
+                                _validateTemperature(value, localizations),
                           ),
                         ),
                         Spacer(flex: 1),

--- a/lib/src/ui/screens/checkup/steps/temperature.dart
+++ b/lib/src/ui/screens/checkup/steps/temperature.dart
@@ -1,3 +1,4 @@
+import 'package:covidnearme/src/ui/widgets/questions/inputs/entry_field.dart';
 import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
 import 'package:covidnearme/src/ui/widgets/scroll_more_indicator.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
@@ -23,12 +24,9 @@ class _TemperatureStepState extends State<TemperatureStep> {
   static const double _celsiusMin = 21.1;
   static const double _fahrenheitMax = 150.0;
   static const double _fahrenheitMin = 70.0;
-  bool get _isCelsius =>
-      _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
+  bool get _isCelsius => _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
   bool get _isFahrenheit =>
-      _degrees != null &&
-      _degrees <= _fahrenheitMax &&
-      _degrees >= _fahrenheitMin;
+      _degrees != null && _degrees <= _fahrenheitMax && _degrees >= _fahrenheitMin;
   bool get _isValid => _degrees != null && (_isCelsius || _isFahrenheit);
   double _degrees;
 
@@ -105,8 +103,7 @@ class _TemperatureStepState extends State<TemperatureStep> {
           appBar: AppBar(
             title: Text(
               localizations.temperatureStepHowToDialogTitle,
-              style: theme.textTheme.headline
-                  .copyWith(color: theme.colorScheme.onBackground),
+              style: theme.textTheme.headline.copyWith(color: theme.colorScheme.onBackground),
               textAlign: TextAlign.center,
             ),
           ),
@@ -159,8 +156,7 @@ class _TemperatureStepState extends State<TemperatureStep> {
                   child: Center(
                     child: RaisedButton(
                       onPressed: () => Navigator.pop(context),
-                      child:
-                          Text(localizations.temperatureStepHowToDialogReturn),
+                      child: Text(localizations.temperatureStepHowToDialogReturn),
                     ),
                   ),
                 ),
@@ -178,8 +174,7 @@ class _TemperatureStepState extends State<TemperatureStep> {
     return BlocBuilder<CheckupBloc, CheckupState>(
       builder: (context, state) {
         final CheckupStateInProgress checkupState = state;
-        final VitalsResponse existingResponse =
-            checkupState.checkup.vitalsResponses.firstWhere(
+        final VitalsResponse existingResponse = checkupState.checkup.vitalsResponses.firstWhere(
           (VitalsResponse response) => response.id == 'temperature',
           orElse: () => null,
         );
@@ -210,36 +205,20 @@ class _TemperatureStepState extends State<TemperatureStep> {
                         Spacer(flex: 1),
                         Expanded(
                           flex: 3,
-                          child: TextFormField(
+                          child: EntryField(
                             initialValue: existingResponse != null
                                 ? existingResponse.response.toString()
                                 : '',
-                            onChanged: (String value) => _updateTemperature(
-                                double.parse(value), checkupState),
-                            decoration: InputDecoration(
-                              errorMaxLines: 2,
-                              border: OutlineInputBorder(),
-                              filled: true,
-                              fillColor: Colors.transparent,
-                              labelText:
-                                  localizations.temperatureStepTemperatureLabel,
-                              hasFloatingPlaceholder: true,
-                              suffix: _isValid
-                                  ? Text(_isCelsius ? '℃' : '℉')
-                                  : null,
-                            ),
+                            onChanged: (String value) =>
+                                _updateTemperature(double.parse(value), checkupState),
+                            label: localizations.temperatureStepTemperatureLabel,
+                            suffix: _isValid ? (_isCelsius ? '℃' : '℉') : null,
                             keyboardType: TextInputType.number,
                             inputFormatters: [
-                              WhitelistingTextInputFormatter(
-                                  RegExp(r'^\d+\.?\d?$')),
+                              WhitelistingTextInputFormatter(RegExp(r'^\d+\.?\d?$')),
                             ],
                             autofocus: true,
-                            validator: (String value) =>
-                                _validateTemperature(value, localizations),
-                            style: TextStyle(
-                              color: Colors.black,
-                              fontSize: 20,
-                            ),
+                            validator: (String value) => _validateTemperature(value, localizations),
                           ),
                         ),
                         Spacer(flex: 1),

--- a/lib/src/ui/widgets/questions/inputs/country_dropdown.dart
+++ b/lib/src/ui/widgets/questions/inputs/country_dropdown.dart
@@ -1,0 +1,383 @@
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:searchable_dropdown/searchable_dropdown.dart';
+
+typedef CountryDropdownSearchFunction = List<int> Function(
+    String keyword, List<DropdownMenuItem<String>> items);
+
+class CountryDropdown extends StatefulWidget {
+  const CountryDropdown({
+    Key key,
+    this.searchHint,
+    this.onChanged,
+    this.searchFunction,
+    this.value,
+    this.iconSize,
+  }) : super(key: key);
+
+  final Widget searchHint;
+  final ValueChanged<String> onChanged;
+  final CountryDropdownSearchFunction searchFunction;
+  final String value;
+  final double iconSize;
+
+  @override
+  _CountryDropdownState createState() => _CountryDropdownState();
+}
+
+class _CountryDropdownState extends State<CountryDropdown> {
+  Map<String, String> countryCodeToName;
+  Map<String, String> nameToCountryCode;
+  List<DropdownMenuItem<String>> _dropdownItems;
+
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    AppLocalizations localizations = AppLocalizations.of(context);
+    _updateCountryCodes(localizations);
+    _dropdownItems = _getDropdownItems(context, localizations);
+  }
+
+  List<int> _findItemsForSearch(
+      String keyword, List<DropdownMenuItem<String>> items) {
+    List<int> results = <int>[];
+    for (int i = 0; i < items.length; ++i) {
+      if (items[i].value == 'None') {
+        continue;
+      }
+      final name = countryCodeToName[items[i].value];
+      if (keyword == null || keyword.isEmpty) {
+        results.add(i);
+      } else {
+        if (name.toLowerCase().contains(keyword.toLowerCase())) {
+          results.add(i);
+        }
+      }
+    }
+    return results;
+  }
+
+  void _updateCountryCodes(AppLocalizations localizations) {
+    countryCodeToName = <String, String>{
+      'AD': localizations.countryCodeAD,
+      'AE': localizations.countryCodeAE,
+      'AF': localizations.countryCodeAF,
+      'AG': localizations.countryCodeAG,
+      'AI': localizations.countryCodeAI,
+      'AL': localizations.countryCodeAL,
+      'AM': localizations.countryCodeAM,
+      'AO': localizations.countryCodeAO,
+      'AQ': localizations.countryCodeAQ,
+      'AR': localizations.countryCodeAR,
+      'AS': localizations.countryCodeAS,
+      'AT': localizations.countryCodeAT,
+      'AU': localizations.countryCodeAU,
+      'AW': localizations.countryCodeAW,
+      'AX': localizations.countryCodeAX,
+      'AZ': localizations.countryCodeAZ,
+      'BA': localizations.countryCodeBA,
+      'BB': localizations.countryCodeBB,
+      'BD': localizations.countryCodeBD,
+      'BE': localizations.countryCodeBE,
+      'BF': localizations.countryCodeBF,
+      'BG': localizations.countryCodeBG,
+      'BH': localizations.countryCodeBH,
+      'BI': localizations.countryCodeBI,
+      'BJ': localizations.countryCodeBJ,
+      'BL': localizations.countryCodeBL,
+      'BM': localizations.countryCodeBM,
+      'BN': localizations.countryCodeBN,
+      'BO': localizations.countryCodeBO,
+      'BQ': localizations.countryCodeBQ,
+      'BR': localizations.countryCodeBR,
+      'BS': localizations.countryCodeBS,
+      'BT': localizations.countryCodeBT,
+      'BV': localizations.countryCodeBV,
+      'BW': localizations.countryCodeBW,
+      'BY': localizations.countryCodeBY,
+      'BZ': localizations.countryCodeBZ,
+      'CA': localizations.countryCodeCA,
+      'CC': localizations.countryCodeCC,
+      'CD': localizations.countryCodeCD,
+      'CF': localizations.countryCodeCF,
+      'CG': localizations.countryCodeCG,
+      'CH': localizations.countryCodeCH,
+      'CI': localizations.countryCodeCI,
+      'CK': localizations.countryCodeCK,
+      'CL': localizations.countryCodeCL,
+      'CM': localizations.countryCodeCM,
+      'CN': localizations.countryCodeCN,
+      'CO': localizations.countryCodeCO,
+      'CR': localizations.countryCodeCR,
+      'CU': localizations.countryCodeCU,
+      'CV': localizations.countryCodeCV,
+      'CW': localizations.countryCodeCW,
+      'CX': localizations.countryCodeCX,
+      'CY': localizations.countryCodeCY,
+      'CZ': localizations.countryCodeCZ,
+      'DE': localizations.countryCodeDE,
+      'DJ': localizations.countryCodeDJ,
+      'DK': localizations.countryCodeDK,
+      'DM': localizations.countryCodeDM,
+      'DO': localizations.countryCodeDO,
+      'DZ': localizations.countryCodeDZ,
+      'EC': localizations.countryCodeEC,
+      'EE': localizations.countryCodeEE,
+      'EG': localizations.countryCodeEG,
+      'EH': localizations.countryCodeEH,
+      'ER': localizations.countryCodeER,
+      'ES': localizations.countryCodeES,
+      'ET': localizations.countryCodeET,
+      'FI': localizations.countryCodeFI,
+      'FJ': localizations.countryCodeFJ,
+      'FK': localizations.countryCodeFK,
+      'FM': localizations.countryCodeFM,
+      'FO': localizations.countryCodeFO,
+      'FR': localizations.countryCodeFR,
+      'GA': localizations.countryCodeGA,
+      'GB': localizations.countryCodeGB,
+      'GD': localizations.countryCodeGD,
+      'GE': localizations.countryCodeGE,
+      'GF': localizations.countryCodeGF,
+      'GG': localizations.countryCodeGG,
+      'GH': localizations.countryCodeGH,
+      'GI': localizations.countryCodeGI,
+      'GL': localizations.countryCodeGL,
+      'GM': localizations.countryCodeGM,
+      'GN': localizations.countryCodeGN,
+      'GP': localizations.countryCodeGP,
+      'GQ': localizations.countryCodeGQ,
+      'GR': localizations.countryCodeGR,
+      'GS': localizations.countryCodeGS,
+      'GT': localizations.countryCodeGT,
+      'GU': localizations.countryCodeGU,
+      'GW': localizations.countryCodeGW,
+      'GY': localizations.countryCodeGY,
+      'HK': localizations.countryCodeHK,
+      'HM': localizations.countryCodeHM,
+      'HN': localizations.countryCodeHN,
+      'HR': localizations.countryCodeHR,
+      'HT': localizations.countryCodeHT,
+      'HU': localizations.countryCodeHU,
+      'ID': localizations.countryCodeID,
+      'IE': localizations.countryCodeIE,
+      'IL': localizations.countryCodeIL,
+      'IM': localizations.countryCodeIM,
+      'IN': localizations.countryCodeIN,
+      'IO': localizations.countryCodeIO,
+      'IQ': localizations.countryCodeIQ,
+      'IR': localizations.countryCodeIR,
+      'IS': localizations.countryCodeIS,
+      'IT': localizations.countryCodeIT,
+      'JE': localizations.countryCodeJE,
+      'JM': localizations.countryCodeJM,
+      'JO': localizations.countryCodeJO,
+      'JP': localizations.countryCodeJP,
+      'KE': localizations.countryCodeKE,
+      'KG': localizations.countryCodeKG,
+      'KH': localizations.countryCodeKH,
+      'KI': localizations.countryCodeKI,
+      'KM': localizations.countryCodeKM,
+      'KN': localizations.countryCodeKN,
+      'KP': localizations.countryCodeKP,
+      'KR': localizations.countryCodeKR,
+      'KW': localizations.countryCodeKW,
+      'KY': localizations.countryCodeKY,
+      'KZ': localizations.countryCodeKZ,
+      'LA': localizations.countryCodeLA,
+      'LB': localizations.countryCodeLB,
+      'LC': localizations.countryCodeLC,
+      'LI': localizations.countryCodeLI,
+      'LK': localizations.countryCodeLK,
+      'LR': localizations.countryCodeLR,
+      'LS': localizations.countryCodeLS,
+      'LT': localizations.countryCodeLT,
+      'LU': localizations.countryCodeLU,
+      'LV': localizations.countryCodeLV,
+      'LY': localizations.countryCodeLY,
+      'MA': localizations.countryCodeMA,
+      'MC': localizations.countryCodeMC,
+      'MD': localizations.countryCodeMD,
+      'ME': localizations.countryCodeME,
+      'MF': localizations.countryCodeMF,
+      'MG': localizations.countryCodeMG,
+      'MH': localizations.countryCodeMH,
+      'MK': localizations.countryCodeMK,
+      'ML': localizations.countryCodeML,
+      'MM': localizations.countryCodeMM,
+      'MN': localizations.countryCodeMN,
+      'MO': localizations.countryCodeMO,
+      'MP': localizations.countryCodeMP,
+      'MQ': localizations.countryCodeMQ,
+      'MR': localizations.countryCodeMR,
+      'MS': localizations.countryCodeMS,
+      'MT': localizations.countryCodeMT,
+      'MU': localizations.countryCodeMU,
+      'MV': localizations.countryCodeMV,
+      'MW': localizations.countryCodeMW,
+      'MX': localizations.countryCodeMX,
+      'MY': localizations.countryCodeMY,
+      'MZ': localizations.countryCodeMZ,
+      'NA': localizations.countryCodeNA,
+      'NC': localizations.countryCodeNC,
+      'NE': localizations.countryCodeNE,
+      'NF': localizations.countryCodeNF,
+      'NG': localizations.countryCodeNG,
+      'NI': localizations.countryCodeNI,
+      'NL': localizations.countryCodeNL,
+      'NO': localizations.countryCodeNO,
+      'NP': localizations.countryCodeNP,
+      'NR': localizations.countryCodeNR,
+      'NU': localizations.countryCodeNU,
+      'NZ': localizations.countryCodeNZ,
+      'OM': localizations.countryCodeOM,
+      'PA': localizations.countryCodePA,
+      'PE': localizations.countryCodePE,
+      'PF': localizations.countryCodePF,
+      'PG': localizations.countryCodePG,
+      'PH': localizations.countryCodePH,
+      'PK': localizations.countryCodePK,
+      'PL': localizations.countryCodePL,
+      'PM': localizations.countryCodePM,
+      'PN': localizations.countryCodePN,
+      'PR': localizations.countryCodePR,
+      'PS': localizations.countryCodePS,
+      'PT': localizations.countryCodePT,
+      'PW': localizations.countryCodePW,
+      'PY': localizations.countryCodePY,
+      'QA': localizations.countryCodeQA,
+      'RE': localizations.countryCodeRE,
+      'RO': localizations.countryCodeRO,
+      'RS': localizations.countryCodeRS,
+      'RU': localizations.countryCodeRU,
+      'RW': localizations.countryCodeRW,
+      'SA': localizations.countryCodeSA,
+      'SB': localizations.countryCodeSB,
+      'SC': localizations.countryCodeSC,
+      'SD': localizations.countryCodeSD,
+      'SE': localizations.countryCodeSE,
+      'SG': localizations.countryCodeSG,
+      'SH': localizations.countryCodeSH,
+      'SI': localizations.countryCodeSI,
+      'SJ': localizations.countryCodeSJ,
+      'SK': localizations.countryCodeSK,
+      'SL': localizations.countryCodeSL,
+      'SM': localizations.countryCodeSM,
+      'SN': localizations.countryCodeSN,
+      'SO': localizations.countryCodeSO,
+      'SR': localizations.countryCodeSR,
+      'SS': localizations.countryCodeSS,
+      'ST': localizations.countryCodeST,
+      'SV': localizations.countryCodeSV,
+      'SX': localizations.countryCodeSX,
+      'SY': localizations.countryCodeSY,
+      'SZ': localizations.countryCodeSZ,
+      'TC': localizations.countryCodeTC,
+      'TD': localizations.countryCodeTD,
+      'TF': localizations.countryCodeTF,
+      'TG': localizations.countryCodeTG,
+      'TH': localizations.countryCodeTH,
+      'TJ': localizations.countryCodeTJ,
+      'TK': localizations.countryCodeTK,
+      'TL': localizations.countryCodeTL,
+      'TM': localizations.countryCodeTM,
+      'TN': localizations.countryCodeTN,
+      'TO': localizations.countryCodeTO,
+      'TR': localizations.countryCodeTR,
+      'TT': localizations.countryCodeTT,
+      'TV': localizations.countryCodeTV,
+      'TW': localizations.countryCodeTW,
+      'TZ': localizations.countryCodeTZ,
+      'UA': localizations.countryCodeUA,
+      'UG': localizations.countryCodeUG,
+      'UM': localizations.countryCodeUM,
+      'UY': localizations.countryCodeUY,
+      'UZ': localizations.countryCodeUZ,
+      'VA': localizations.countryCodeVA,
+      'VC': localizations.countryCodeVC,
+      'VE': localizations.countryCodeVE,
+      'VG': localizations.countryCodeVG,
+      'VI': localizations.countryCodeVI,
+      'VN': localizations.countryCodeVN,
+      'VU': localizations.countryCodeVU,
+      'WF': localizations.countryCodeWF,
+      'WS': localizations.countryCodeWS,
+      'YE': localizations.countryCodeYE,
+      'YT': localizations.countryCodeYT,
+      'ZA': localizations.countryCodeZA,
+      'ZM': localizations.countryCodeZM,
+      'ZW': localizations.countryCodeZW,
+    };
+    nameToCountryCode = <String, String>{};
+    for (final String code in countryCodeToName.keys) {
+      nameToCountryCode[countryCodeToName[code]] = code;
+    }
+  }
+
+  List<DropdownMenuItem<String>> _getDropdownItems(
+      BuildContext context, AppLocalizations localizations) {
+    final List<String> countries = nameToCountryCode.keys.toList();
+    countries.sort();
+    final List<DropdownMenuItem<String>> result = countries
+        .map<DropdownMenuItem<String>>(
+          (String country) => DropdownMenuItem<String>(
+            child: Text(
+              country,
+              style: Theme.of(context).textTheme.subhead,
+              overflow: TextOverflow.ellipsis,
+            ),
+            value: nameToCountryCode[country],
+          ),
+        )
+        .toList();
+
+    // Add the "No selection" selection.
+    result.insert(
+      0,
+      DropdownMenuItem<String>(
+        child: Text(localizations.locationStepNoCountrySelected,
+            style: Theme.of(context).textTheme.button.copyWith(
+                  fontStyle: FontStyle.italic,
+                )),
+        value: 'None',
+      ),
+    );
+    return result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+    if (countryCodeToName == null) {
+      _updateCountryCodes(localizations);
+    }
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: 100),
+      child: Align(
+        alignment: AlignmentDirectional.topStart,
+        child: Row(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(localizations.locationStepCountryButtonLabel,
+                  style: Theme.of(context).textTheme.title),
+            ),
+            Expanded(
+              child: SearchableDropdown(
+                searchHint: widget.searchHint ??
+                    Text(localizations.locationStepCountrySearchPrompt),
+                onChanged: widget.onChanged,
+                searchFn: widget.searchFunction ?? _findItemsForSearch,
+                items: _dropdownItems,
+                style: Theme.of(context).textTheme.subhead,
+                value: widget.value,
+                iconSize: 40,
+                isExpanded: true,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/questions/inputs/entry_field.dart
+++ b/lib/src/ui/widgets/questions/inputs/entry_field.dart
@@ -33,25 +33,28 @@ class EntryField extends StatelessWidget {
   Widget build(BuildContext context) {
     return ConstrainedBox(
       constraints: BoxConstraints(minHeight: 100),
-      child: TextFormField(
-        initialValue: initialValue,
-        onChanged: onChanged,
-        decoration: InputDecoration(
-          border: OutlineInputBorder(),
-          enabledBorder: OutlineInputBorder(),
-          labelText: label,
-          suffix: suffix != null ? Text(suffix) : null,
-          helperText: helperText,
-          hasFloatingPlaceholder: true,
-        ),
-        keyboardType: keyboardType,
-        autovalidate: true,
-        validator: validator,
-        autofocus: autofocus,
-        inputFormatters: inputFormatters,
-        style: TextStyle(
-          color: Colors.black,
-          fontSize: 20,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 10.0),
+        child: TextFormField(
+          initialValue: initialValue,
+          onChanged: onChanged,
+          decoration: InputDecoration(
+            border: OutlineInputBorder(),
+            enabledBorder: OutlineInputBorder(),
+            labelText: label,
+            suffix: suffix != null ? Text(suffix) : null,
+            helperText: helperText,
+            hasFloatingPlaceholder: true,
+          ),
+          keyboardType: keyboardType,
+          autovalidate: true,
+          validator: validator,
+          autofocus: autofocus,
+          inputFormatters: inputFormatters,
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 20,
+          ),
         ),
       ),
     );

--- a/lib/src/ui/widgets/questions/inputs/entry_field.dart
+++ b/lib/src/ui/widgets/questions/inputs/entry_field.dart
@@ -9,6 +9,7 @@ class EntryField extends StatelessWidget {
     this.initialValue,
     this.onChanged,
     this.label,
+    this.suffix,
     this.helperText,
     this.validator,
     this.keyboardType = TextInputType.text,
@@ -22,6 +23,7 @@ class EntryField extends StatelessWidget {
   final String helperText;
   final ValueChanged<String> onChanged;
   final String label;
+  final String suffix;
   final FormFieldValidator<String> validator;
   final TextInputType keyboardType;
   final List<TextInputFormatter> inputFormatters;
@@ -38,6 +40,7 @@ class EntryField extends StatelessWidget {
           border: OutlineInputBorder(),
           enabledBorder: OutlineInputBorder(),
           labelText: label,
+          suffix: suffix != null ? Text(suffix) : null,
           helperText: helperText,
           hasFloatingPlaceholder: true,
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -602,6 +602,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.23.1"
+  searchable_dropdown:
+    dependency: "direct main"
+    description:
+      name: searchable_dropdown
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   share:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,9 +37,10 @@ dependencies:
   hydrated_bloc: ^3.0.0
   intl: ^0.16.0
   meta: ^1.1.8
-  path_provider: ^1.6.5
   path: ^1.6.4
+  path_provider: ^1.6.5
   provider: ^4.0.4
+  searchable_dropdown: ^1.1.2
   share: ^0.6.3+6
   uuid: ^2.0.4
 


### PR DESCRIPTION
This adds a new helper widget, `CountryDropdown` that is a searchable dropdown widget for use on the location page.

It also adds the localized names for each of the 249 countries defined in [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).

While I was in there, I converted the text field in the temperature page to use the EntryField helper widget (for a consistent look), and fixed the location page's radio button to use the right color when selected.

Looks like this:
![Screenshot_1585596756](https://user-images.githubusercontent.com/8867023/77953956-c256ba00-7282-11ea-922c-5d2a35a24b1d.png)

![Screenshot_1585596770](https://user-images.githubusercontent.com/8867023/77953961-c5ea4100-7282-11ea-9c40-1e68b8717e52.png)

![Screenshot_1585596787](https://user-images.githubusercontent.com/8867023/77953976-cb478b80-7282-11ea-8ae7-cb95a78db08a.png)

