### PR TITLE
Semantics to covid near me

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -341,6 +341,11 @@
     "description": "Heading on the initial screen. The name of the app, CovidNearMe, should not be translated"
   },
 
+  "tutorialIntroStepWelcomeSemanticsLabel": "Welcome to the Covid Near Me App",
+  "@tutorialIntroStepWelcomeSemanticsLabel": {
+    "description": "Semantics label for tutorialIntroStepWelcome which makes CovidNearMe legible for screen readers"
+  },
+
   "tutorialIntroStepCompleteACheckup": "Complete a daily health checkup.",
   "@tutorialIntroStepCompleteACheckup": {
     "description": "Describes the outcome of running the app"
@@ -364,6 +369,11 @@
   "getStartedStepJoined": "You've joined the CovidNearMe community!",
   "@getStartedStepJoined": {
     "description": "Heading that's shown after the user has agreed to the app license. The name of the app, CovidNearMe, should not be translated"
+  },
+
+  "getStartedStepJoinedSemanticsLabel": "You've joined the Covid Near Me community!",
+  "@getStartedStepJoinedSemanticsLabel": {
+    "description": "Semantics label for getStartedStepJoined which makes CovidNearMe legible for screen readers"
   },
 
   "consentStepDidNotAgree": "DID NOT AGREE",

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -1,3 +1,4 @@
+
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -63,9 +64,7 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-      : assert(locale != null),
-        localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
@@ -74,8 +73,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -87,8 +85,7 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -96,7 +93,9 @@ abstract class AppLocalizations {
   ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en')
+  ];
 
   // The long informed consent question asked of users
   String get consentStepQuestion;
@@ -293,6 +292,9 @@ abstract class AppLocalizations {
   // Heading on the initial screen. The name of the app, CovidNearMe, should not be translated
   String get tutorialIntroStepWelcome;
 
+  // Semantics label for tutorialIntroStepWelcome which makes CovidNearMe legible for screen readers
+  String get tutorialIntroStepWelcomeSemanticsLabel;
+
   // Describes the outcome of running the app
   String get tutorialIntroStepCompleteACheckup;
 
@@ -307,6 +309,9 @@ abstract class AppLocalizations {
 
   // Heading that's shown after the user has agreed to the app license. The name of the app, CovidNearMe, should not be translated
   String get getStartedStepJoined;
+
+  // Semantics label for getStartedStepJoined which makes CovidNearMe legible for screen readers
+  String get getStartedStepJoinedSemanticsLabel;
 
   // Label for the button that indicates that the user did not accept the app license
   String get consentStepDidNotAgree;
@@ -444,8 +449,7 @@ abstract class AppLocalizations {
   String get scrollMoreIndicatorMessage;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -454,19 +458,16 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations _lookupAppLocalizations(Locale locale) {
-  switch (locale.languageCode) {
-    case 'en':
-      return AppLocalizationsEn();
+  switch(locale.languageCode) {
+    case 'en': return AppLocalizationsEn();
   }
-  assert(false,
-      'AppLocalizations.delegate failed to load unsupported locale "$locale"');
+  assert(false, 'AppLocalizations.delegate failed to load unsupported locale "$locale"');
   return null;
 }

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
@@ -64,7 +63,9 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : assert(locale != null), localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+      : assert(locale != null),
+        localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   // ignore: unused_field
   final String localeName;
@@ -73,7 +74,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -85,7 +87,8 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
     delegate,
     GlobalMaterialLocalizations.delegate,
     GlobalCupertinoLocalizations.delegate,
@@ -93,9 +96,7 @@ abstract class AppLocalizations {
   ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[
-    Locale('en')
-  ];
+  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
   // The long informed consent question asked of users
   String get consentStepQuestion;
@@ -449,7 +450,8 @@ abstract class AppLocalizations {
   String get scrollMoreIndicatorMessage;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -458,16 +460,19 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations _lookupAppLocalizations(Locale locale) {
-  switch(locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
+  switch (locale.languageCode) {
+    case 'en':
+      return AppLocalizationsEn();
   }
-  assert(false, 'AppLocalizations.delegate failed to load unsupported locale "$locale"');
+  assert(false,
+      'AppLocalizations.delegate failed to load unsupported locale "$locale"');
   return null;
 }

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -1,3 +1,4 @@
+
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -27,39 +28,31 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get deniedConsentHeading => 'Consent denied';
 
   @override
-  String get deniedConsentMessage =>
-      'We need you to grant the App consent to perform the required action.';
+  String get deniedConsentMessage => 'We need you to grant the App consent to perform the required action.';
 
   @override
   String get assessmentScreenTitle => 'Your Personalized Assessment';
 
   @override
-  String get negativeAssessmentTestingCriteria =>
-      'You don\'t meet testing criteria';
+  String get negativeAssessmentTestingCriteria => 'You don\'t meet testing criteria';
 
   @override
-  String get negativeAssessmentCheckInTomorrow =>
-      'If you continue to experience symptoms, please check in tomorrow.';
+  String get negativeAssessmentCheckInTomorrow => 'If you continue to experience symptoms, please check in tomorrow.';
 
   @override
-  String get negativeAssessmentConsultPhysician =>
-      'If they become serious, please consult a physician.';
+  String get negativeAssessmentConsultPhysician => 'If they become serious, please consult a physician.';
 
   @override
-  String get positiveAssessmentConsultPhysician =>
-      'Please contact your physician';
+  String get positiveAssessmentConsultPhysician => 'Please contact your physician';
 
   @override
-  String get positiveAssessmentShowingSymptoms =>
-      'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
+  String get positiveAssessmentShowingSymptoms => 'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
 
   @override
-  String get positiveAssessmentDoNotPanic =>
-      'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
+  String get positiveAssessmentDoNotPanic => 'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
 
   @override
-  String get checkupScreenErrorRetrievingExperience =>
-      'There was an error retrieving the checkup experience. Please try again later.';
+  String get checkupScreenErrorRetrievingExperience => 'There was an error retrieving the checkup experience. Please try again later.';
 
   @override
   String get checkupScreenHUDLabel => 'Loading your assessment';
@@ -69,14 +62,14 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
 
   @override
   String checkupProgressBarPercentCompleteText(int stepIndex, int stepCount) {
-    final intl.NumberFormat stepIndexNumberFormat =
-        intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepIndexNumberFormat = intl.NumberFormat.compactLong(
       locale: localeName,
+      
     );
     final String stepIndexString = stepIndexNumberFormat.format(stepIndex);
-    final intl.NumberFormat stepCountNumberFormat =
-        intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepCountNumberFormat = intl.NumberFormat.compactLong(
       locale: localeName,
+      
     );
     final String stepCountString = stepCountNumberFormat.format(stepCount);
 
@@ -90,86 +83,70 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get checkupStepFinishedNext => 'NEXT';
 
   @override
-  String get checkupStepFinishedAnswerAllQuestions =>
-      'Please answer all the questions to continue';
+  String get checkupStepFinishedAnswerAllQuestions => 'Please answer all the questions to continue';
 
   @override
   String get introStepTimeForYourCheckup => 'It\'s time for your checkup.';
 
   @override
-  String get introStepWeWillAskQuestions =>
-      'We will ask you a few questions and have you take your temperature.';
+  String get introStepWeWillAskQuestions => 'We will ask you a few questions and have you take your temperature.';
 
   @override
-  String get introStepAtTheEnd =>
-      'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
+  String get introStepAtTheEnd => 'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
 
   @override
-  String get introStepSwitchLabelContributeData =>
-      'Contribute my data to the COVID-19 response effort.';
+  String get introStepSwitchLabelContributeData => 'Contribute my data to the COVID-19 response effort.';
 
   @override
-  String get introStepSwitchLabelCollectPostalCode =>
-      'We will collect your zip code.';
+  String get introStepSwitchLabelCollectPostalCode => 'We will collect your zip code.';
 
   @override
   String get introStepButtonStartLabel => 'START CHECKUP';
 
   @override
-  String get subjectiveStepQuestionsLoadedError =>
-      'Questions could not be loaded.';
+  String get subjectiveStepQuestionsLoadedError => 'Questions could not be loaded.';
 
   @override
   String get temperatureStepWhenHeading => 'When?';
 
   @override
-  String get temperatureStepWait30Minutes =>
-      'Wait 30 minutes after eating, drinking, or exercising';
+  String get temperatureStepWait30Minutes => 'Wait 30 minutes after eating, drinking, or exercising';
 
   @override
-  String get temperatureStepWait6Hours =>
-      'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
+  String get temperatureStepWait6Hours => 'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
 
   @override
   String get temperatureStepHowHeading => 'How?';
 
   @override
-  String get temperatureStepPleaseEnterValueBelow =>
-      'Please enter a value below 150 ℉';
+  String get temperatureStepPleaseEnterValueBelow => 'Please enter a value below 150 ℉';
 
   @override
-  String get temperatureStepPleaseEnterValueAbove =>
-      'Please enter a value above 70 ℉';
+  String get temperatureStepPleaseEnterValueAbove => 'Please enter a value above 70 ℉';
 
   @override
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
-  String get temperatureStepTemperatureOutOfRangeError =>
-      'Please enter a valid temperature value.';
+  String get temperatureStepTemperatureOutOfRangeError => 'Please enter a valid temperature value.';
 
   @override
   String get temperatureStepTemperatureLabel => 'Temperature';
 
   @override
-  String get temperatureStepHowToDialogStep1 =>
-      'Wash your hands using soap and water';
+  String get temperatureStepHowToDialogStep1 => 'Wash your hands using soap and water';
 
   @override
-  String get temperatureStepHowToDialogStep2 =>
-      'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
+  String get temperatureStepHowToDialogStep2 => 'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
 
   @override
-  String get temperatureStepHowToDialogStep3 =>
-      'Put the tip of your thermometer under your tongue and gently close your lips.';
+  String get temperatureStepHowToDialogStep3 => 'Put the tip of your thermometer under your tongue and gently close your lips.';
 
   @override
-  String get temperatureStepHowToDialogStep4 =>
-      'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
+  String get temperatureStepHowToDialogStep4 => 'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
 
   @override
-  String get temperatureStepHowToDialogStep5 =>
-      'Take out your thermometer and record your temperature.';
+  String get temperatureStepHowToDialogStep5 => 'Take out your thermometer and record your temperature.';
 
   @override
   String get temperatureStepHowToDialogReturn => 'RETURN TO CHECKUP';
@@ -190,15 +167,13 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get locationStepInvalidZipCode => 'Please enter a valid USPS ZIP code';
 
   @override
-  String get locationStepInvalidCountry =>
-      'Please just enter the name of your country';
+  String get locationStepInvalidCountry => 'Please just enter the name of your country';
 
   @override
   String get locationStepZipCode => '5-Digit ZIP Code';
 
   @override
-  String get locationStepCountryHelper =>
-      'If you are not in the US, what is your country?';
+  String get locationStepCountryHelper => 'If you are not in the US, what is your country?';
 
   @override
   String get locationStepInUSA => 'In the United States';
@@ -213,33 +188,28 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get homeScreenHeading => 'Concerned about your health?';
 
   @override
-  String get homeScreenDoYouHaveSymptoms =>
-      'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
+  String get homeScreenDoYouHaveSymptoms => 'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
 
   @override
   String get homeScreenCheckupButtonLabel => 'START HEALTH CHECKUP';
 
   @override
-  String get homeScreenYouHaveCompletedCheckup =>
-      'You have completed your checkup for today!';
+  String get homeScreenYouHaveCompletedCheckup => 'You have completed your checkup for today!';
 
   @override
-  String get homeScreenCheckBackTomorrow =>
-      'If you continue to experience symptoms, please check back tomorrow.';
+  String get homeScreenCheckBackTomorrow => 'If you continue to experience symptoms, please check back tomorrow.';
 
   @override
   String get homeScreenViewMyAssessment => 'View my assessment';
 
   @override
-  String get shareAppDownloadPrompt =>
-      'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
+  String get shareAppDownloadPrompt => 'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
 
   @override
   String get shareAppProtectYourCommunity => 'Protect Your Community';
 
   @override
-  String get shareAppWithFriendsEtc =>
-      'Share this app with your friends, coworkers, and family (especially grandparents).';
+  String get shareAppWithFriendsEtc => 'Share this app with your friends, coworkers, and family (especially grandparents).';
 
   @override
   String get shareAppNow => 'SHARE NOW';
@@ -254,19 +224,19 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get staySafeLimitContact => 'Limit contact with other people.';
 
   @override
-  String get staySafeCheckBackIf =>
-      'Check back in if you continue to experience symptoms.';
+  String get staySafeCheckBackIf => 'Check back in if you continue to experience symptoms.';
 
   @override
   String get tutorialIntroStepWelcome => 'Welcome to the CovidNearMe App';
 
   @override
-  String get tutorialIntroStepCompleteACheckup =>
-      'Complete a daily health checkup.';
+  String get tutorialIntroStepWelcomeSemanticsLabel => 'Welcome to the Covid Near Me App';
 
   @override
-  String get tutorialIntroStepReceiveAssessment =>
-      'Receive a personalized health assessment.';
+  String get tutorialIntroStepCompleteACheckup => 'Complete a daily health checkup.';
+
+  @override
+  String get tutorialIntroStepReceiveAssessment => 'Receive a personalized health assessment.';
 
   @override
   String get tutorialIntroStepAidEffort => 'Aid COVID-19 response efforts.';
@@ -275,8 +245,10 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get tutorialIntroStepLearnMore => 'LEARN MORE';
 
   @override
-  String get getStartedStepJoined =>
-      'You\'ve joined the CovidNearMe community!';
+  String get getStartedStepJoined => 'You\'ve joined the CovidNearMe community!';
+
+  @override
+  String get getStartedStepJoinedSemanticsLabel => 'You\'ve joined the Covid Near Me community!';
 
   @override
   String get consentStepDidNotAgree => 'DID NOT AGREE';
@@ -300,20 +272,16 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get networkUnavailableBannerConnectToWiFi => 'CONNECT TO WIFI';
 
   @override
-  String get networkUnavailableBannerMessage =>
-      'You seem to be offline. Please check your network settings and try again.';
+  String get networkUnavailableBannerMessage => 'You seem to be offline. Please check your network settings and try again.';
 
   @override
-  String get deniedConsentBackButton =>
-      'Go back to the informed consent screen';
+  String get deniedConsentBackButton => 'Go back to the informed consent screen';
 
   @override
-  String get questionShortnessOfBreathTitle =>
-      'Are you experiencing shortness of breath?';
+  String get questionShortnessOfBreathTitle => 'Are you experiencing shortness of breath?';
 
   @override
-  String get questionShortnessOfBreathSubtitle =>
-      'Do you feel like you can\'t get enough air?';
+  String get questionShortnessOfBreathSubtitle => 'Do you feel like you can\'t get enough air?';
 
   @override
   String get questionShortnessOfBreathAnswer0 => 'None';
@@ -334,12 +302,10 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionShortnessOfBreathSemantics1 => 'Mild shortness of breath';
 
   @override
-  String get questionShortnessOfBreathSemantics2 =>
-      'Moderate shortness of breath';
+  String get questionShortnessOfBreathSemantics2 => 'Moderate shortness of breath';
 
   @override
-  String get questionShortnessOfBreathSemantics3 =>
-      'Severe shortness of breath';
+  String get questionShortnessOfBreathSemantics3 => 'Severe shortness of breath';
 
   @override
   String get questionHaveACoughTitle => 'Do you have a cough?';
@@ -369,8 +335,7 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveACoughSemantics3 => 'Uncontrollable cough';
 
   @override
-  String get questionHaveNauseaTitle =>
-      'Do you feel nauseous, like you might throw up or wish you could?';
+  String get questionHaveNauseaTitle => 'Do you feel nauseous, like you might throw up or wish you could?';
 
   @override
   String get questionHaveNauseaAnswer0 => 'None';
@@ -397,8 +362,7 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveNauseaSemantics3 => 'Severe nausea';
 
   @override
-  String get questionHaveAFeverTitle =>
-      'Have you felt like you\'ve had a fever today?';
+  String get questionHaveAFeverTitle => 'Have you felt like you\'ve had a fever today?';
 
   @override
   String get questionHaveAFeverAnswer0 => 'No';

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -1,4 +1,3 @@
-
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
 import 'app_localizations.dart';
@@ -28,31 +27,39 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get deniedConsentHeading => 'Consent denied';
 
   @override
-  String get deniedConsentMessage => 'We need you to grant the App consent to perform the required action.';
+  String get deniedConsentMessage =>
+      'We need you to grant the App consent to perform the required action.';
 
   @override
   String get assessmentScreenTitle => 'Your Personalized Assessment';
 
   @override
-  String get negativeAssessmentTestingCriteria => 'You don\'t meet testing criteria';
+  String get negativeAssessmentTestingCriteria =>
+      'You don\'t meet testing criteria';
 
   @override
-  String get negativeAssessmentCheckInTomorrow => 'If you continue to experience symptoms, please check in tomorrow.';
+  String get negativeAssessmentCheckInTomorrow =>
+      'If you continue to experience symptoms, please check in tomorrow.';
 
   @override
-  String get negativeAssessmentConsultPhysician => 'If they become serious, please consult a physician.';
+  String get negativeAssessmentConsultPhysician =>
+      'If they become serious, please consult a physician.';
 
   @override
-  String get positiveAssessmentConsultPhysician => 'Please contact your physician';
+  String get positiveAssessmentConsultPhysician =>
+      'Please contact your physician';
 
   @override
-  String get positiveAssessmentShowingSymptoms => 'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
+  String get positiveAssessmentShowingSymptoms =>
+      'You are showing symptoms that may be of concern. Please limit your contact with other people until you have a chance to follow up with a physician.';
 
   @override
-  String get positiveAssessmentDoNotPanic => 'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
+  String get positiveAssessmentDoNotPanic =>
+      'Do not panic. This is only a preliminary assessment and not a formal medical diagnosis.';
 
   @override
-  String get checkupScreenErrorRetrievingExperience => 'There was an error retrieving the checkup experience. Please try again later.';
+  String get checkupScreenErrorRetrievingExperience =>
+      'There was an error retrieving the checkup experience. Please try again later.';
 
   @override
   String get checkupScreenHUDLabel => 'Loading your assessment';
@@ -62,14 +69,14 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
 
   @override
   String checkupProgressBarPercentCompleteText(int stepIndex, int stepCount) {
-    final intl.NumberFormat stepIndexNumberFormat = intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepIndexNumberFormat =
+        intl.NumberFormat.compactLong(
       locale: localeName,
-      
     );
     final String stepIndexString = stepIndexNumberFormat.format(stepIndex);
-    final intl.NumberFormat stepCountNumberFormat = intl.NumberFormat.compactLong(
+    final intl.NumberFormat stepCountNumberFormat =
+        intl.NumberFormat.compactLong(
       locale: localeName,
-      
     );
     final String stepCountString = stepCountNumberFormat.format(stepCount);
 
@@ -83,70 +90,86 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get checkupStepFinishedNext => 'NEXT';
 
   @override
-  String get checkupStepFinishedAnswerAllQuestions => 'Please answer all the questions to continue';
+  String get checkupStepFinishedAnswerAllQuestions =>
+      'Please answer all the questions to continue';
 
   @override
   String get introStepTimeForYourCheckup => 'It\'s time for your checkup.';
 
   @override
-  String get introStepWeWillAskQuestions => 'We will ask you a few questions and have you take your temperature.';
+  String get introStepWeWillAskQuestions =>
+      'We will ask you a few questions and have you take your temperature.';
 
   @override
-  String get introStepAtTheEnd => 'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
+  String get introStepAtTheEnd =>
+      'At the end, you will receive a personalized COVID-19 risk assessment and recommendations for staying healthy.';
 
   @override
-  String get introStepSwitchLabelContributeData => 'Contribute my data to the COVID-19 response effort.';
+  String get introStepSwitchLabelContributeData =>
+      'Contribute my data to the COVID-19 response effort.';
 
   @override
-  String get introStepSwitchLabelCollectPostalCode => 'We will collect your zip code.';
+  String get introStepSwitchLabelCollectPostalCode =>
+      'We will collect your zip code.';
 
   @override
   String get introStepButtonStartLabel => 'START CHECKUP';
 
   @override
-  String get subjectiveStepQuestionsLoadedError => 'Questions could not be loaded.';
+  String get subjectiveStepQuestionsLoadedError =>
+      'Questions could not be loaded.';
 
   @override
   String get temperatureStepWhenHeading => 'When?';
 
   @override
-  String get temperatureStepWait30Minutes => 'Wait 30 minutes after eating, drinking, or exercising';
+  String get temperatureStepWait30Minutes =>
+      'Wait 30 minutes after eating, drinking, or exercising';
 
   @override
-  String get temperatureStepWait6Hours => 'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
+  String get temperatureStepWait6Hours =>
+      'Wait at least 6 hours after taking medicines that can lower your temperature (like Acetaminophen, Paracetamol, Ibuprofen, and Aspirin)';
 
   @override
   String get temperatureStepHowHeading => 'How?';
 
   @override
-  String get temperatureStepPleaseEnterValueBelow => 'Please enter a value below 150 ℉';
+  String get temperatureStepPleaseEnterValueBelow =>
+      'Please enter a value below 150 ℉';
 
   @override
-  String get temperatureStepPleaseEnterValueAbove => 'Please enter a value above 70 ℉';
+  String get temperatureStepPleaseEnterValueAbove =>
+      'Please enter a value above 70 ℉';
 
   @override
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
-  String get temperatureStepTemperatureOutOfRangeError => 'Please enter a valid temperature value.';
+  String get temperatureStepTemperatureOutOfRangeError =>
+      'Please enter a valid temperature value.';
 
   @override
   String get temperatureStepTemperatureLabel => 'Temperature';
 
   @override
-  String get temperatureStepHowToDialogStep1 => 'Wash your hands using soap and water';
+  String get temperatureStepHowToDialogStep1 =>
+      'Wash your hands using soap and water';
 
   @override
-  String get temperatureStepHowToDialogStep2 => 'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
+  String get temperatureStepHowToDialogStep2 =>
+      'Wash the tip of your thermometer using soap and warm water or rubbing alcohol. Rinse.';
 
   @override
-  String get temperatureStepHowToDialogStep3 => 'Put the tip of your thermometer under your tongue and gently close your lips.';
+  String get temperatureStepHowToDialogStep3 =>
+      'Put the tip of your thermometer under your tongue and gently close your lips.';
 
   @override
-  String get temperatureStepHowToDialogStep4 => 'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
+  String get temperatureStepHowToDialogStep4 =>
+      'Keep your lips closed and the thermometer under your tongue until you hear a beep.';
 
   @override
-  String get temperatureStepHowToDialogStep5 => 'Take out your thermometer and record your temperature.';
+  String get temperatureStepHowToDialogStep5 =>
+      'Take out your thermometer and record your temperature.';
 
   @override
   String get temperatureStepHowToDialogReturn => 'RETURN TO CHECKUP';
@@ -167,13 +190,15 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get locationStepInvalidZipCode => 'Please enter a valid USPS ZIP code';
 
   @override
-  String get locationStepInvalidCountry => 'Please just enter the name of your country';
+  String get locationStepInvalidCountry =>
+      'Please just enter the name of your country';
 
   @override
   String get locationStepZipCode => '5-Digit ZIP Code';
 
   @override
-  String get locationStepCountryHelper => 'If you are not in the US, what is your country?';
+  String get locationStepCountryHelper =>
+      'If you are not in the US, what is your country?';
 
   @override
   String get locationStepInUSA => 'In the United States';
@@ -188,28 +213,33 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get homeScreenHeading => 'Concerned about your health?';
 
   @override
-  String get homeScreenDoYouHaveSymptoms => 'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
+  String get homeScreenDoYouHaveSymptoms =>
+      'Are you experiencing symptoms? Have you been in contact with someone who is infected?';
 
   @override
   String get homeScreenCheckupButtonLabel => 'START HEALTH CHECKUP';
 
   @override
-  String get homeScreenYouHaveCompletedCheckup => 'You have completed your checkup for today!';
+  String get homeScreenYouHaveCompletedCheckup =>
+      'You have completed your checkup for today!';
 
   @override
-  String get homeScreenCheckBackTomorrow => 'If you continue to experience symptoms, please check back tomorrow.';
+  String get homeScreenCheckBackTomorrow =>
+      'If you continue to experience symptoms, please check back tomorrow.';
 
   @override
   String get homeScreenViewMyAssessment => 'View my assessment';
 
   @override
-  String get shareAppDownloadPrompt => 'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
+  String get shareAppDownloadPrompt =>
+      'Worried that you might have COVID-19? Download this app to check up on your health and support your community: APP_LINK';
 
   @override
   String get shareAppProtectYourCommunity => 'Protect Your Community';
 
   @override
-  String get shareAppWithFriendsEtc => 'Share this app with your friends, coworkers, and family (especially grandparents).';
+  String get shareAppWithFriendsEtc =>
+      'Share this app with your friends, coworkers, and family (especially grandparents).';
 
   @override
   String get shareAppNow => 'SHARE NOW';
@@ -224,19 +254,23 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get staySafeLimitContact => 'Limit contact with other people.';
 
   @override
-  String get staySafeCheckBackIf => 'Check back in if you continue to experience symptoms.';
+  String get staySafeCheckBackIf =>
+      'Check back in if you continue to experience symptoms.';
 
   @override
   String get tutorialIntroStepWelcome => 'Welcome to the CovidNearMe App';
 
   @override
-  String get tutorialIntroStepWelcomeSemanticsLabel => 'Welcome to the Covid Near Me App';
+  String get tutorialIntroStepWelcomeSemanticsLabel =>
+      'Welcome to the Covid Near Me App';
 
   @override
-  String get tutorialIntroStepCompleteACheckup => 'Complete a daily health checkup.';
+  String get tutorialIntroStepCompleteACheckup =>
+      'Complete a daily health checkup.';
 
   @override
-  String get tutorialIntroStepReceiveAssessment => 'Receive a personalized health assessment.';
+  String get tutorialIntroStepReceiveAssessment =>
+      'Receive a personalized health assessment.';
 
   @override
   String get tutorialIntroStepAidEffort => 'Aid COVID-19 response efforts.';
@@ -245,10 +279,12 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get tutorialIntroStepLearnMore => 'LEARN MORE';
 
   @override
-  String get getStartedStepJoined => 'You\'ve joined the CovidNearMe community!';
+  String get getStartedStepJoined =>
+      'You\'ve joined the CovidNearMe community!';
 
   @override
-  String get getStartedStepJoinedSemanticsLabel => 'You\'ve joined the Covid Near Me community!';
+  String get getStartedStepJoinedSemanticsLabel =>
+      'You\'ve joined the Covid Near Me community!';
 
   @override
   String get consentStepDidNotAgree => 'DID NOT AGREE';
@@ -272,16 +308,20 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get networkUnavailableBannerConnectToWiFi => 'CONNECT TO WIFI';
 
   @override
-  String get networkUnavailableBannerMessage => 'You seem to be offline. Please check your network settings and try again.';
+  String get networkUnavailableBannerMessage =>
+      'You seem to be offline. Please check your network settings and try again.';
 
   @override
-  String get deniedConsentBackButton => 'Go back to the informed consent screen';
+  String get deniedConsentBackButton =>
+      'Go back to the informed consent screen';
 
   @override
-  String get questionShortnessOfBreathTitle => 'Are you experiencing shortness of breath?';
+  String get questionShortnessOfBreathTitle =>
+      'Are you experiencing shortness of breath?';
 
   @override
-  String get questionShortnessOfBreathSubtitle => 'Do you feel like you can\'t get enough air?';
+  String get questionShortnessOfBreathSubtitle =>
+      'Do you feel like you can\'t get enough air?';
 
   @override
   String get questionShortnessOfBreathAnswer0 => 'None';
@@ -302,10 +342,12 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionShortnessOfBreathSemantics1 => 'Mild shortness of breath';
 
   @override
-  String get questionShortnessOfBreathSemantics2 => 'Moderate shortness of breath';
+  String get questionShortnessOfBreathSemantics2 =>
+      'Moderate shortness of breath';
 
   @override
-  String get questionShortnessOfBreathSemantics3 => 'Severe shortness of breath';
+  String get questionShortnessOfBreathSemantics3 =>
+      'Severe shortness of breath';
 
   @override
   String get questionHaveACoughTitle => 'Do you have a cough?';
@@ -335,7 +377,8 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveACoughSemantics3 => 'Uncontrollable cough';
 
   @override
-  String get questionHaveNauseaTitle => 'Do you feel nauseous, like you might throw up or wish you could?';
+  String get questionHaveNauseaTitle =>
+      'Do you feel nauseous, like you might throw up or wish you could?';
 
   @override
   String get questionHaveNauseaAnswer0 => 'None';
@@ -362,7 +405,8 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveNauseaSemantics3 => 'Severe nausea';
 
   @override
-  String get questionHaveAFeverTitle => 'Have you felt like you\'ve had a fever today?';
+  String get questionHaveAFeverTitle =>
+      'Have you felt like you\'ve had a fever today?';
 
   @override
   String get questionHaveAFeverAnswer0 => 'No';

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -58,7 +58,8 @@ class _HomeScreenState extends State<HomeScreen> {
               margin: EdgeInsets.only(bottom: 20),
               child: Text(
                 localizations.getStartedStepJoined,
-                semanticsLabel: localizations.getStartedStepJoinedSemanticsLabel,
+                semanticsLabel:
+                    localizations.getStartedStepJoinedSemanticsLabel,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.title,
               ),
@@ -158,7 +159,10 @@ class _HomeScreenState extends State<HomeScreen> {
       builder: (context, state) {
         return Scaffold(
           appBar: AppBar(
-            title: Text('CovidNearMe', semanticsLabel: 'Covid Near Me',),
+            title: Text(
+              'CovidNearMe',
+              semanticsLabel: 'Covid Near Me',
+            ),
             leading: kReleaseMode
                 ? null
                 : IconButton(

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -58,6 +58,7 @@ class _HomeScreenState extends State<HomeScreen> {
               margin: EdgeInsets.only(bottom: 20),
               child: Text(
                 localizations.getStartedStepJoined,
+                semanticsLabel: localizations.getStartedStepJoinedSemanticsLabel,
                 textAlign: TextAlign.center,
                 style: Theme.of(context).textTheme.title,
               ),
@@ -157,7 +158,7 @@ class _HomeScreenState extends State<HomeScreen> {
       builder: (context, state) {
         return Scaffold(
           appBar: AppBar(
-            title: Text('CovidNearMe'),
+            title: Text('CovidNearMe', semanticsLabel: 'Covid Near Me',),
             leading: kReleaseMode
                 ? null
                 : IconButton(

--- a/lib/src/ui/screens/tutorial/steps/intro.dart
+++ b/lib/src/ui/screens/tutorial/steps/intro.dart
@@ -30,6 +30,7 @@ class IntroStep extends StatelessWidget {
                 margin: EdgeInsets.only(bottom: 40),
                 child: Text(
                   localizations.tutorialIntroStepWelcome,
+                  semanticsLabel: localizations.tutorialIntroStepWelcomeSemanticsLabel,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.title,
                 ),

--- a/lib/src/ui/screens/tutorial/steps/intro.dart
+++ b/lib/src/ui/screens/tutorial/steps/intro.dart
@@ -30,7 +30,8 @@ class IntroStep extends StatelessWidget {
                 margin: EdgeInsets.only(bottom: 40),
                 child: Text(
                   localizations.tutorialIntroStepWelcome,
-                  semanticsLabel: localizations.tutorialIntroStepWelcomeSemanticsLabel,
+                  semanticsLabel:
+                      localizations.tutorialIntroStepWelcomeSemanticsLabel,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.title,
                 ),


### PR DESCRIPTION
Whenever the app has any text that has CovidNearMe the text reader doesn't read it as expected. Added a semantics label to each text widget that has covidnearme so it pronunciate the words Covid Near Me as expected.

Closes #113