### PR TITLE
Add remaining questions

### DIFF
--- a/lib/src/data/models/questions.dart
+++ b/lib/src/data/models/questions.dart
@@ -1,4 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'questions.g.dart';
 
@@ -8,15 +9,21 @@ abstract class Question {
   final String subtitle;
 
   Question({
-    this.id,
-    this.title,
+    @required this.id,
+    @required this.title,
     this.subtitle,
-  });
+  })  : assert(id != null),
+        assert(title != null),
+        assert(title.isNotEmpty);
 
   factory Question.fromJson(Map<String, dynamic> json) {
     switch (json['type']) {
       case ScaleQuestion.TYPE:
         return ScaleQuestion.fromJson(json);
+      case TextFieldQuestion.TYPE:
+        return TextFieldQuestion.fromJson(json);
+      case TemperatureQuestion.TYPE:
+        return TemperatureQuestion.fromJson(json);
       default:
         return UnknownQuestion.fromJson(json);
     }
@@ -24,22 +31,85 @@ abstract class Question {
   Map<String, dynamic> toJson() => throw UnimplementedError();
 }
 
+// Returns null if the input value is valid, and a localized error string if it
+// is not valid,
+typedef TextFieldQuestionValidator = String Function(String value);
+
+@JsonSerializable()
+class TextFieldQuestion extends Question {
+  static const TYPE = 'text_field';
+
+  final String initialValue;
+  final TextFieldQuestionValidator validator;
+
+  TextFieldQuestion({
+    @required String id,
+    @required String title,
+    String subtitle,
+    this.initialValue,
+    this.validator,
+  }) : super(
+          id: id,
+          title: title,
+          subtitle: subtitle,
+        );
+
+  factory TextFieldQuestion.fromJson(Map<String, dynamic> json) =>
+      _$TextFieldQuestionFromJson(json);
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> json = _$TextFieldQuestionToJson(this);
+    json['type'] = TYPE;
+    return json;
+  }
+}
+
+@JsonSerializable()
+class TemperatureQuestion extends Question {
+  static const TYPE = 'temperature';
+
+  final double initialValue;
+
+  TemperatureQuestion({
+    @required String id,
+    @required String title,
+    String subtitle,
+    this.initialValue,
+  }) : super(
+          id: id,
+          title: title,
+          subtitle: subtitle,
+        );
+
+  factory TemperatureQuestion.fromJson(Map<String, dynamic> json) =>
+      _$TemperatureQuestionFromJson(json);
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> json = _$TemperatureQuestionToJson(this);
+    json['type'] = TYPE;
+    return json;
+  }
+}
+
 @JsonSerializable()
 class ScaleQuestion extends Question {
-  static const TYPE = 'slider';
+  static const TYPE = 'scale';
 
   final int initialValue;
   final List<String> labels;
   final List<String> semanticLabels;
+  final bool vertical;
 
   ScaleQuestion({
-    String id,
-    String title,
+    @required String id,
+    @required String title,
     String subtitle,
     this.initialValue,
-    this.labels,
-    this.semanticLabels,
-  }) : super(
+    @required this.labels,
+    @required this.semanticLabels,
+    this.vertical = false,
+  })  : assert(labels != null),
+        assert(semanticLabels != null),
+        assert(vertical != null),
+        super(
           id: id,
           title: title,
           subtitle: subtitle,
@@ -59,8 +129,8 @@ class UnknownQuestion extends Question {
   final String type;
 
   UnknownQuestion({
-    id,
-    title,
+    @required id,
+    @required title,
     subtitle,
     this.type,
   }) : super(

--- a/lib/src/data/models/questions.dart
+++ b/lib/src/data/models/questions.dart
@@ -40,14 +40,12 @@ class TextFieldQuestion extends Question {
   static const TYPE = 'text_field';
 
   final String initialValue;
-  final TextFieldQuestionValidator validator;
 
   TextFieldQuestion({
     @required String id,
     @required String title,
     String subtitle,
     this.initialValue,
-    this.validator,
   }) : super(
           id: id,
           title: title,

--- a/lib/src/data/models/questions.g.dart
+++ b/lib/src/data/models/questions.g.dart
@@ -6,6 +6,41 @@ part of 'questions.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+TextFieldQuestion _$TextFieldQuestionFromJson(Map<String, dynamic> json) {
+  return TextFieldQuestion(
+    id: json['id'],
+    title: json['title'],
+    subtitle: json['subtitle'],
+    initialValue: json['initial_value'],
+  );
+}
+
+Map<String, dynamic> _$TextFieldQuestionToJson(TextFieldQuestion instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'subtitle': instance.subtitle,
+      'initial_value': instance.initialValue,
+    };
+
+TemperatureQuestion _$TemperatureQuestionFromJson(Map<String, dynamic> json) {
+  return TemperatureQuestion(
+    id: json['id'],
+    title: json['title'],
+    subtitle: json['subtitle'],
+    initialValue: (json['initial_value'] as num).toDouble(),
+  );
+}
+
+Map<String, dynamic> _$TemperatureQuestionToJson(
+        TemperatureQuestion instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'subtitle': instance.subtitle,
+      'initial_value': instance.initialValue.toStringAsFixed(1),
+    };
+
 ScaleQuestion _$ScaleQuestionFromJson(Map<String, dynamic> json) {
   return ScaleQuestion(
     id: json['id'] as String,

--- a/lib/src/data/models/questions.g.dart
+++ b/lib/src/data/models/questions.g.dart
@@ -8,10 +8,10 @@ part of 'questions.dart';
 
 TextFieldQuestion _$TextFieldQuestionFromJson(Map<String, dynamic> json) {
   return TextFieldQuestion(
-    id: json['id'],
-    title: json['title'],
-    subtitle: json['subtitle'],
-    initialValue: json['initial_value'],
+    id: json['id'] as String,
+    title: json['title'] as String,
+    subtitle: json['subtitle'] as String,
+    initialValue: json['initial_value'] as String,
   );
 }
 
@@ -25,10 +25,10 @@ Map<String, dynamic> _$TextFieldQuestionToJson(TextFieldQuestion instance) =>
 
 TemperatureQuestion _$TemperatureQuestionFromJson(Map<String, dynamic> json) {
   return TemperatureQuestion(
-    id: json['id'],
-    title: json['title'],
-    subtitle: json['subtitle'],
-    initialValue: (json['initial_value'] as num).toDouble(),
+    id: json['id'] as String,
+    title: json['title'] as String,
+    subtitle: json['subtitle'] as String,
+    initialValue: (json['initial_value'] as num)?.toDouble(),
   );
 }
 
@@ -38,7 +38,7 @@ Map<String, dynamic> _$TemperatureQuestionToJson(
       'id': instance.id,
       'title': instance.title,
       'subtitle': instance.subtitle,
-      'initial_value': instance.initialValue.toStringAsFixed(1),
+      'initial_value': instance.initialValue,
     };
 
 ScaleQuestion _$ScaleQuestionFromJson(Map<String, dynamic> json) {
@@ -50,6 +50,7 @@ ScaleQuestion _$ScaleQuestionFromJson(Map<String, dynamic> json) {
     labels: (json['labels'] as List)?.map((e) => e as String)?.toList(),
     semanticLabels:
         (json['semantic_labels'] as List)?.map((e) => e as String)?.toList(),
+    vertical: json['vertical'] as bool,
   );
 }
 
@@ -61,6 +62,7 @@ Map<String, dynamic> _$ScaleQuestionToJson(ScaleQuestion instance) =>
       'initial_value': instance.initialValue,
       'labels': instance.labels,
       'semantic_labels': instance.semanticLabels,
+      'vertical': instance.vertical,
     };
 
 UnknownQuestion _$UnknownQuestionFromJson(Map<String, dynamic> json) {

--- a/lib/src/data/repositories/questions.dart
+++ b/lib/src/data/repositories/questions.dart
@@ -9,7 +9,6 @@ class QuestionsRepository {
         ScaleQuestion(
           id: '5325',
           title: localizations.questionShortnessOfBreathTitle,
-          subtitle: localizations.questionShortnessOfBreathSubtitle,
           initialValue: null,
           labels: [
             localizations.questionShortnessOfBreathAnswer0,
@@ -42,6 +41,26 @@ class QuestionsRepository {
           ],
         ),
         ScaleQuestion(
+          id: '4664',
+          title: localizations.questionHaveAFeverTitle,
+          initialValue: null,
+          labels: [
+            localizations.questionHaveAFeverAnswer0,
+            localizations.questionHaveAFeverAnswer1,
+            localizations.questionHaveAFeverAnswer2,
+          ],
+          semanticLabels: [
+            localizations.questionHaveAFeverSemantics0,
+            localizations.questionHaveAFeverSemantics1,
+            localizations.questionHaveAFeverSemantics2,
+          ],
+        ),
+        TemperatureQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '1',
+          title: localizations.questionHowHighWasYourFever,
+        ),
+        ScaleQuestion(
           // TODO(gspencergoog): Insert correct ID here.
           id: '0',
           title: localizations.questionHaveNauseaTitle,
@@ -58,11 +77,6 @@ class QuestionsRepository {
             localizations.questionHaveNauseaSemantics2,
             localizations.questionHaveNauseaSemantics3,
           ],
-        ),
-        TemperatureQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '1',
-          title: localizations.questionHowHighWasYourFever,
         ),
         ScaleQuestion(
           // TODO(gspencergoog): Insert correct ID here.
@@ -97,21 +111,6 @@ class QuestionsRepository {
           id: '3',
           title: localizations.questionWhatWasPositiveTitle,
           initialValue: null,
-        ),
-        ScaleQuestion(
-          id: '4664',
-          title: localizations.questionHaveAFeverTitle,
-          initialValue: null,
-          labels: [
-            localizations.questionHaveAFeverAnswer0,
-            localizations.questionHaveAFeverAnswer1,
-            localizations.questionHaveAFeverAnswer2,
-          ],
-          semanticLabels: [
-            localizations.questionHaveAFeverSemantics0,
-            localizations.questionHaveAFeverSemantics1,
-            localizations.questionHaveAFeverSemantics2,
-          ],
         ),
         ScaleQuestion(
           // TODO(gspencergoog): Insert correct ID here.

--- a/lib/src/data/repositories/questions.dart
+++ b/lib/src/data/repositories/questions.dart
@@ -59,6 +59,45 @@ class QuestionsRepository {
             localizations.questionHaveNauseaSemantics3,
           ],
         ),
+        TemperatureQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '1',
+          title: localizations.questionHowHighWasYourFever,
+        ),
+        ScaleQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '2',
+          title: localizations.questionHaveYouBeenFluTestedTitle,
+          initialValue: null,
+          labels: [
+            localizations.questionNo,
+            localizations.questionYes,
+          ],
+          semanticLabels: [
+            localizations.questionHaveAFeverSemantics1,
+            localizations.questionHaveAFeverSemantics0,
+          ],
+        ),
+        ScaleQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '2',
+          title: localizations.questionFluTestPositiveTitle,
+          initialValue: null,
+          labels: [
+            localizations.questionNo,
+            localizations.questionYes,
+          ],
+          semanticLabels: [
+            localizations.questionFluTestPositiveSemantics1,
+            localizations.questionFluTestPositiveSemantics0,
+          ],
+        ),
+        TextFieldQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '3',
+          title: localizations.questionWhatWasPositiveTitle,
+          initialValue: null,
+        ),
         ScaleQuestion(
           id: '4664',
           title: localizations.questionHaveAFeverTitle,
@@ -72,6 +111,41 @@ class QuestionsRepository {
             localizations.questionHaveAFeverSemantics0,
             localizations.questionHaveAFeverSemantics1,
             localizations.questionHaveAFeverSemantics2,
+          ],
+        ),
+        ScaleQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '4',
+          title: localizations.questionTryForTestingTitle,
+          initialValue: null,
+          labels: [
+            localizations.questionNo,
+            localizations.questionYes,
+          ],
+          semanticLabels: [
+            localizations.questionTryForTestingSemantics1,
+            localizations.questionTryForTestingSemantics0,
+          ],
+        ),
+        ScaleQuestion(
+          // TODO(gspencergoog): Insert correct ID here.
+          id: '4',
+          title: localizations.questionCovid19TestResultTitle,
+          vertical: true,
+          initialValue: null,
+          labels: [
+            localizations.questionCovid19TestResultAnswer0,
+            localizations.questionCovid19TestResultAnswer1,
+            localizations.questionCovid19TestResultAnswer2,
+            localizations.questionCovid19TestResultAnswer3,
+            localizations.questionCovid19TestResultAnswer4,
+          ],
+          semanticLabels: [
+            localizations.questionCovid19TestResultAnswer0,
+            localizations.questionCovid19TestResultAnswer1,
+            localizations.questionCovid19TestResultAnswer2,
+            localizations.questionCovid19TestResultAnswer3,
+            localizations.questionCovid19TestResultAnswer4,
           ],
         ),
       ];

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -585,6 +585,101 @@
     "description": "Question accessibility semantics description."
   },
 
+  "questionHowHighWasYourFever": "How high did your temperature get today (if you took it)?",
+  "@questionHowHighWasYourFever": {
+    "description": "Question title."
+  },
+
+  "questionHaveYouBeenFluTestedTitle": "Have you been tested for flu, pneumonia, or other respiratory illness?",
+  "@questionHaveYouBeenFluTestedTitle": {
+    "description": "Question title."
+  },
+
+  "questionYes": "Yes",
+  "@questionYes": {
+    "description": "Question answer."
+  },
+
+  "questionNo": "No",
+  "@questionNo": {
+    "description": "Question answer."
+  },
+
+  "questionHaveYouBeenFluTestedSemantics0": "Yes, I have been tested for flu, pneumonia, or other respiratory illness.",
+  "@questionHaveYouBeenFluTestedSemantics0": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionHaveYouBeenFluTestedSemantics1": "No, I have not been tested for flu, pneumonia, or other respiratory illness.",
+  "@questionHaveYouBeenFluTestedSemantics1": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionFluTestPositiveTitle": "Was the test positive?",
+  "@questionFluTestPositiveTitle": {
+    "description": "Question title."
+  },
+
+  "questionFluTestPositiveSemantics0": "Yes, the test was positive.",
+  "@questionFluTestPositiveSemantics0": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionFluTestPositiveSemantics1": "No, the test was negative.",
+  "@questionFluTestPositiveSemantics1": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionWhatWasPositiveTitle": "What did you have?",
+  "@questionWhatWasPositiveTitle": {
+    "description": "Question title."
+  },
+
+  "questionTryForTestingTitle": "Did you try to get tested for COVID-19?",
+    "@questionTryForTestingTitle": {
+      "description": "Question title."
+  },
+
+  "questionTryForTestingSemantics0": "Yes, I tried to get tested for COVID-19.",
+    "@questionTryForTestingSemantics0": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionTryForTestingSemantics1": "No, I didn't try to get tested for COVID-19.",
+    "@questionTryForTestingSemantics1": {
+    "description": "Question accessibility semantics description."
+  },
+
+  "questionCovid19TestResultTitle": "What was the result?",
+    "@questionCovid19TestResultTitle": {
+      "description": "Question title."
+  },
+
+  "questionCovid19TestResultAnswer0": "Negative, I don't have COVID-19",
+    "@questionCovid19TestResultAnswer0": {
+      "description": "Question answer."
+  },
+
+  "questionCovid19TestResultAnswer1": "Positive, I have COVID-19",
+    "@questionCovid19TestResultAnswer1": {
+      "description": "Question answer."
+  },
+
+  "questionCovid19TestResultAnswer2": "I don't know yet",
+    "@questionCovid19TestResultAnswer2": {
+      "description": "Question answer."
+  },
+
+  "questionCovid19TestResultAnswer3": "The clinic didn't have tests",
+    "@questionCovid19TestResultAnswer3": {
+      "description": "Question answer."
+  },
+
+  "questionCovid19TestResultAnswer4": "I was turned away because I wasn't sick enough",
+    "@questionCovid19TestResultAnswer4": {
+      "description": "Question answer."
+  },
+
   "scrollMoreIndicatorMessage": "SCROLL FOR MORE",
   "@scrollMoreIndicatorMessage": {
     "description": "Let the user that they can scroll to see more content"

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -440,6 +440,63 @@ abstract class AppLocalizations {
   // Question accessibility semantics description.
   String get questionHaveAFeverSemantics2;
 
+  // Question title.
+  String get questionHowHighWasYourFever;
+
+  // Question title.
+  String get questionHaveYouBeenFluTestedTitle;
+
+  // Question answer.
+  String get questionYes;
+
+  // Question answer.
+  String get questionNo;
+
+  // Question accessibility semantics description.
+  String get questionHaveYouBeenFluTestedSemantics0;
+
+  // Question accessibility semantics description.
+  String get questionHaveYouBeenFluTestedSemantics1;
+
+  // Question title.
+  String get questionFluTestPositiveTitle;
+
+  // Question accessibility semantics description.
+  String get questionFluTestPositiveSemantics0;
+
+  // Question accessibility semantics description.
+  String get questionFluTestPositiveSemantics1;
+
+  // Question title.
+  String get questionWhatWasPositiveTitle;
+
+  // Question title.
+  String get questionTryForTestingTitle;
+
+  // Question accessibility semantics description.
+  String get questionTryForTestingSemantics0;
+
+  // Question accessibility semantics description.
+  String get questionTryForTestingSemantics1;
+
+  // Question title.
+  String get questionCovid19TestResultTitle;
+
+  // Question answer.
+  String get questionCovid19TestResultAnswer0;
+
+  // Question answer.
+  String get questionCovid19TestResultAnswer1;
+
+  // Question answer.
+  String get questionCovid19TestResultAnswer2;
+
+  // Question answer.
+  String get questionCovid19TestResultAnswer3;
+
+  // Question answer.
+  String get questionCovid19TestResultAnswer4;
+
   // Let the user that they can scroll to see more content
   String get scrollMoreIndicatorMessage;
 }

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -419,5 +419,72 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get questionHaveAFeverSemantics2 => 'Severe fever, I\'m burning up';
 
   @override
+  String get questionHowHighWasYourFever =>
+      'How high did your temperature get today (if you took it)?';
+
+  @override
+  String get questionHaveYouBeenFluTestedTitle =>
+      'Have you been tested for flu, pneumonia, or other respiratory illness?';
+
+  @override
+  String get questionYes => 'Yes';
+
+  @override
+  String get questionNo => 'No';
+
+  @override
+  String get questionHaveYouBeenFluTestedSemantics0 =>
+      'Yes, I have been tested for flu, pneumonia, or other respiratory illness.';
+
+  @override
+  String get questionHaveYouBeenFluTestedSemantics1 =>
+      'No, I have not been tested for flu, pneumonia, or other respiratory illness.';
+
+  @override
+  String get questionFluTestPositiveTitle => 'Was the test positive?';
+
+  @override
+  String get questionFluTestPositiveSemantics0 => 'Yes, the test was positive.';
+
+  @override
+  String get questionFluTestPositiveSemantics1 => 'No, the test was negative.';
+
+  @override
+  String get questionWhatWasPositiveTitle => 'What did you have?';
+
+  @override
+  String get questionTryForTestingTitle =>
+      'Did you try to get tested for COVID-19?';
+
+  @override
+  String get questionTryForTestingSemantics0 =>
+      'Yes, I tried to get tested for COVID-19.';
+
+  @override
+  String get questionTryForTestingSemantics1 =>
+      'No, I didn\'t try to get tested for COVID-19.';
+
+  @override
+  String get questionCovid19TestResultTitle => 'What was the result?';
+
+  @override
+  String get questionCovid19TestResultAnswer0 =>
+      'Negative, I don\'t have COVID-19';
+
+  @override
+  String get questionCovid19TestResultAnswer1 => 'Positive, I have COVID-19';
+
+  @override
+  String get questionCovid19TestResultAnswer2 => 'I don\'t know yet';
+
+  @override
+  String get questionCovid19TestResultAnswer3 =>
+      'The clinic didn\'t have tests';
+
+  @override
+  String get questionCovid19TestResultAnswer4 =>
+      'I was turned away because I wasn\'t sick enough';
+
+  @override
   String get scrollMoreIndicatorMessage => 'SCROLL FOR MORE';
 }

--- a/lib/src/ui/screens/symptom_report/steps/location.dart
+++ b/lib/src/ui/screens/symptom_report/steps/location.dart
@@ -166,8 +166,8 @@ class _LocationStepState extends State<LocationStep> {
                     padding: const EdgeInsets.only(bottom: 20.0),
                     child: Column(
                       children: <Widget>[
-                        _LabeledRadio<bool>(
-                          onTap: () {
+                        LabeledRadio<bool>(
+                          onChanged: () {
                             setState(() {
                               _isUSA = true;
                               _updateValidity(_displayedZip, null);
@@ -177,8 +177,8 @@ class _LocationStepState extends State<LocationStep> {
                           groupValue: _isUSA,
                           label: localizations.locationStepInUSA,
                         ),
-                        _LabeledRadio<bool>(
-                          onTap: () {
+                        LabeledRadio<bool>(
+                          onChanged: () {
                             setState(() {
                               _isUSA = false;
                               _updateValidity(null, _displayedCountry);
@@ -229,37 +229,6 @@ class _LocationStepState extends State<LocationStep> {
           ),
         );
       },
-    );
-  }
-}
-
-class _LabeledRadio<T> extends StatelessWidget {
-  const _LabeledRadio({
-    this.onTap,
-    this.value,
-    this.groupValue,
-    this.label,
-  });
-
-  final VoidCallback onTap;
-  final T value;
-  final T groupValue;
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: <Widget>[
-        Radio<T>(
-          onChanged: (T value) => onTap(),
-          value: value,
-          groupValue: groupValue,
-        ),
-        GestureDetector(
-          onTap: onTap,
-          child: Text(label, style: Theme.of(context).textTheme.button),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/ui/screens/symptom_report/steps/location.dart
+++ b/lib/src/ui/screens/symptom_report/steps/location.dart
@@ -12,7 +12,7 @@ import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'index.dart';
 
 class LocationStep extends StatefulWidget implements SymptomReportStep {
-  bool get isLastStep => true;
+  bool get isLastStep => false;
 
   @override
   _LocationStepState createState() => _LocationStepState();

--- a/lib/src/ui/screens/symptom_report/steps/location.dart
+++ b/lib/src/ui/screens/symptom_report/steps/location.dart
@@ -222,11 +222,7 @@ class _LocationStepState extends State<LocationStep> {
                       validator: (String string) =>
                           _validateCountry(string, localizations),
                     ),
-                  StepFinishedButton(
-                    isLastStep: false,
-                    validated:
-                        (_isUSA && _zipIsValid) || (!_isUSA && _countryIsValid),
-                  ),
+                  StepFinishedButton(validated: true),
                 ],
               ),
             ),

--- a/lib/src/ui/screens/symptom_report/steps/temperature.dart
+++ b/lib/src/ui/screens/symptom_report/steps/temperature.dart
@@ -1,14 +1,12 @@
+import 'package:covidnearme/src/ui/widgets/questions/inputs/temperature_field.dart';
 import 'package:covidnearme/src/blocs/symptom_report/symptom_report.dart';
 import 'package:covidnearme/src/data/models/symptom_report.dart';
 import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
-import 'package:covidnearme/src/ui/widgets/scroll_more_indicator.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:covidnearme/src/l10n/app_localizations.dart';
-import 'package:covidnearme/src/ui/widgets/tutorial_step.dart';
 import 'package:covidnearme/src/ui/utils/symptom_reports.dart';
 import 'index.dart';
 
@@ -20,54 +18,17 @@ class TemperatureStep extends StatefulWidget implements SymptomReportStep {
 }
 
 class _TemperatureStepState extends State<TemperatureStep> {
-  static const double _celsiusMax = 65.5;
-  static const double _celsiusMin = 21.1;
-  static const double _fahrenheitMax = 150.0;
-  static const double _fahrenheitMin = 70.0;
-  bool get _isCelsius =>
-      _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
-  bool get _isFahrenheit =>
-      _degrees != null &&
-      _degrees <= _fahrenheitMax &&
-      _degrees >= _fahrenheitMin;
-  bool get _isValid => _degrees != null && (_isCelsius || _isFahrenheit);
-  double _degrees;
-
-  String _validateTemperature(String value, AppLocalizations localizations) {
-    if (value.isNotEmpty) {
-      final double degrees = double.parse(value);
-      if (degrees < _celsiusMin ||
-          degrees > _fahrenheitMax ||
-          (degrees < _fahrenheitMin && degrees > _celsiusMax)) {
-        return localizations.temperatureStepTemperatureOutOfRangeError;
-      }
-    }
-    return null;
-  }
-
-  double _toFahrenheit(double value) {
-    if (_isFahrenheit) return value;
-    return value * (9.0 / 5.0) + 32.0;
-  }
-
   void _updateTemperature(
     double value,
     SymptomReportStateInProgress symptomReportState,
   ) {
-    setState(() {
-      _degrees = value;
-    });
-    if (!_isValid) {
-      return;
-    }
-
     updateSymptomReport(
       symptomReportState: symptomReportState,
       context: context,
       updateFunction: (SymptomReport symptomReport) {
         final QuestionResponse newResponse = QuestionResponse(
           questionId: 'temperature',
-          response: _toFahrenheit(value),
+          response: value,
         );
 
         // Check if we have an existing response
@@ -85,91 +46,6 @@ class _TemperatureStepState extends State<TemperatureStep> {
         }
 
         return symptomReport;
-      },
-    );
-  }
-
-  Future<void> _showInstructions(BuildContext context) async {
-    final categoryFontStyle = TextStyle(
-      color: Theme.of(context).primaryColor,
-      fontWeight: FontWeight.bold,
-      fontSize: 18,
-    );
-
-    ScrollController controller = ScrollController();
-
-    await showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        final AppLocalizations localizations = AppLocalizations.of(context);
-        final ThemeData theme = Theme.of(context);
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(
-              localizations.temperatureStepHowToDialogTitle,
-              style: theme.textTheme.headline
-                  .copyWith(color: theme.colorScheme.onBackground),
-              textAlign: TextAlign.center,
-            ),
-          ),
-          body: ScrollMoreIndicator(
-            controller: controller,
-            child: ListView(
-              controller: controller,
-              padding: EdgeInsets.all(20),
-              children: <Widget>[
-                Text(
-                  localizations.temperatureStepWhenHeading,
-                  style: categoryFontStyle,
-                ),
-                SizedBox(height: 10),
-                _InstructionStep(
-                  text: localizations.temperatureStepWait30Minutes,
-                  number: 1,
-                ),
-                _InstructionStep(
-                  text: localizations.temperatureStepWait6Hours,
-                  number: 2,
-                ),
-                Text(
-                  localizations.temperatureStepHowHeading,
-                  style: categoryFontStyle,
-                ),
-                SizedBox(height: 10),
-                _InstructionStep(
-                  text: localizations.temperatureStepHowToDialogStep1,
-                  number: 1,
-                ),
-                _InstructionStep(
-                  text: localizations.temperatureStepHowToDialogStep2,
-                  number: 2,
-                ),
-                _InstructionStep(
-                  text: localizations.temperatureStepHowToDialogStep3,
-                  number: 3,
-                ),
-                _InstructionStep(
-                  text: localizations.temperatureStepHowToDialogStep4,
-                  number: 4,
-                ),
-                _InstructionStep(
-                  text: localizations.temperatureStepHowToDialogStep5,
-                  number: 5,
-                ),
-                Container(
-                  margin: EdgeInsets.only(top: 20),
-                  child: Center(
-                    child: RaisedButton(
-                      onPressed: () => Navigator.pop(context),
-                      child:
-                          Text(localizations.temperatureStepHowToDialogReturn),
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
       },
     );
   }
@@ -205,59 +81,21 @@ class _TemperatureStepState extends State<TemperatureStep> {
                     ),
                   ),
                   ConstrainedBox(
-                    constraints: BoxConstraints(minHeight: 100),
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Spacer(flex: 1),
-                        Expanded(
-                          flex: 3,
-                          child: TextFormField(
-                            initialValue: existingResponse != null
-                                ? existingResponse.response.toString()
-                                : '',
-                            onChanged: (String value) => _updateTemperature(
-                                double.parse(value), symtomReportState),
-                            decoration: InputDecoration(
-                              errorMaxLines: 2,
-                              border: OutlineInputBorder(),
-                              filled: true,
-                              fillColor: Colors.transparent,
-                              labelText:
-                                  localizations.temperatureStepTemperatureLabel,
-                              hasFloatingPlaceholder: true,
-                              suffix: _isValid
-                                  ? Text(_isCelsius ? '℃' : '℉')
-                                  : null,
-                            ),
-                            keyboardType: TextInputType.number,
-                            inputFormatters: [
-                              WhitelistingTextInputFormatter(
-                                  RegExp(r'^\d+\.?\d?$')),
-                            ],
-                            autofocus: true,
-                            validator: (String value) =>
-                                _validateTemperature(value, localizations),
-                            style: TextStyle(
-                              color: Colors.black,
-                              fontSize: 20,
-                            ),
-                          ),
-                        ),
-                        Spacer(flex: 1),
-                      ],
-                    ),
-                  ),
-                  Container(
-                    margin: EdgeInsets.only(top: 25, bottom: 40),
-                    child: RaisedButton(
-                      onPressed: () => _showInstructions(context),
-                      child: Text(localizations.temperatureStepHelp),
+                    constraints: BoxConstraints(minHeight: 120),
+                    child: TemperatureField(
+                      initialValue: existingResponse != null
+                          ? existingResponse.response
+                          : null,
+                      onChanged: (double value) =>
+                          _updateTemperature(value, symtomReportState),
+                      label: localizations.temperatureStepTemperatureLabel,
+                      minHeight: 0.0,
+                      autofocus: true,
                     ),
                   ),
                   StepFinishedButton(
                     isLastStep: true,
-                    validated: _isValid,
+                    validated: true,
                   ),
                 ],
               ),
@@ -265,24 +103,6 @@ class _TemperatureStepState extends State<TemperatureStep> {
           ),
         );
       },
-    );
-  }
-}
-
-class _InstructionStep extends StatelessWidget {
-  const _InstructionStep({Key key, this.text, this.number}) : super(key: key);
-
-  final String text;
-  final int number;
-
-  @override
-  Widget build(BuildContext context) {
-    return TutorialStep(
-      text: text,
-      number: number,
-      fontSize: 16.0,
-      leadingBackgroundColor: Theme.of(context).colorScheme.secondary,
-      numberColor: Theme.of(context).colorScheme.onSecondary,
     );
   }
 }

--- a/lib/src/ui/screens/symptom_report/steps/temperature.dart
+++ b/lib/src/ui/screens/symptom_report/steps/temperature.dart
@@ -1,13 +1,14 @@
-import 'package:covidnearme/src/ui/widgets/questions/inputs/temperature_field.dart';
-import 'package:covidnearme/src/blocs/symptom_report/symptom_report.dart';
-import 'package:covidnearme/src/data/models/symptom_report.dart';
-import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
-import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:covidnearme/src/blocs/symptom_report/symptom_report.dart';
+import 'package:covidnearme/src/data/models/symptom_report.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:covidnearme/src/ui/utils/symptom_reports.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/temperature_field.dart';
+import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
+import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
+
 import 'index.dart';
 
 class TemperatureStep extends StatefulWidget implements SymptomReportStep {
@@ -55,9 +56,9 @@ class _TemperatureStepState extends State<TemperatureStep> {
     final AppLocalizations localizations = AppLocalizations.of(context);
     return BlocBuilder<SymptomReportBloc, SymptomReportState>(
       builder: (context, state) {
-        final SymptomReportStateInProgress symtomReportState = state;
+        final SymptomReportStateInProgress symptomReportState = state;
         final QuestionResponse existingResponse =
-            symtomReportState.symptomReport.questionResponses.firstWhere(
+            symptomReportState.symptomReport.questionResponses.firstWhere(
           (QuestionResponse response) => response.questionId == 'temperature',
           orElse: () => null,
         );
@@ -87,7 +88,7 @@ class _TemperatureStepState extends State<TemperatureStep> {
                           ? existingResponse.response
                           : null,
                       onChanged: (double value) =>
-                          _updateTemperature(value, symtomReportState),
+                          _updateTemperature(value, symptomReportState),
                       label: localizations.temperatureStepTemperatureLabel,
                       minHeight: 0.0,
                       autofocus: true,

--- a/lib/src/ui/screens/symptom_report/symptom_report.dart
+++ b/lib/src/ui/screens/symptom_report/symptom_report.dart
@@ -48,7 +48,8 @@ class _SymptomReportScreenState extends State<SymptomReportScreen> {
 
 class SymptomReportScreenBody extends StatefulWidget {
   @override
-  _SymptomReportScreenBodyState createState() => _SymptomReportScreenBodyState();
+  _SymptomReportScreenBodyState createState() =>
+      _SymptomReportScreenBodyState();
 }
 
 class _SymptomReportScreenBodyState extends State<SymptomReportScreenBody> {

--- a/lib/src/ui/screens/symptom_report/symptom_report_loaded_body.dart
+++ b/lib/src/ui/screens/symptom_report/symptom_report_loaded_body.dart
@@ -12,14 +12,16 @@ import 'symptom_report_progress_bar.dart';
 
 class SymptomReportLoadedBody extends StatefulWidget {
   @override
-  _SymptomReportLoadedBodyState createState() => _SymptomReportLoadedBodyState();
+  _SymptomReportLoadedBodyState createState() =>
+      _SymptomReportLoadedBodyState();
 }
 
 class _SymptomReportLoadedBodyState extends State<SymptomReportLoadedBody> {
   int currentIndex = 0;
   SymptomReportStep currentStep = steps[0];
 
-  void _saveCurrentLocation(SymptomReportStateInProgress symptomReportState) async {
+  void _saveCurrentLocation(
+      SymptomReportStateInProgress symptomReportState) async {
     final Geolocator geolocator = Geolocator();
 
     try {

--- a/lib/src/ui/widgets/questions/inputs/entry_field.dart
+++ b/lib/src/ui/widgets/questions/inputs/entry_field.dart
@@ -9,28 +9,33 @@ class EntryField extends StatelessWidget {
     this.initialValue,
     this.onChanged,
     this.label,
+    this.suffix,
     this.helperText,
     this.validator,
     this.keyboardType = TextInputType.text,
     this.inputFormatters,
+    this.minHeight = 100,
     this.autofocus = false,
   })  : assert(keyboardType != null),
         assert(autofocus != null),
+        assert(minHeight != null),
         super(key: key);
 
   final String initialValue;
   final String helperText;
   final ValueChanged<String> onChanged;
   final String label;
+  final String suffix;
   final FormFieldValidator<String> validator;
   final TextInputType keyboardType;
   final List<TextInputFormatter> inputFormatters;
+  final double minHeight;
   final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     return ConstrainedBox(
-      constraints: BoxConstraints(minHeight: 100),
+      constraints: BoxConstraints(minHeight: minHeight),
       child: TextFormField(
         initialValue: initialValue,
         onChanged: onChanged,
@@ -40,6 +45,8 @@ class EntryField extends StatelessWidget {
           labelText: label,
           helperText: helperText,
           hasFloatingPlaceholder: true,
+          errorMaxLines: 4,
+          suffix: suffix != null ? Text(suffix) : null,
         ),
         keyboardType: keyboardType,
         autovalidate: true,

--- a/lib/src/ui/widgets/questions/inputs/index.dart
+++ b/lib/src/ui/widgets/questions/inputs/index.dart
@@ -1,2 +1,4 @@
 export 'entry_field.dart';
+export 'labeled_radio.dart';
 export 'radio_button_scale.dart';
+export 'temperature_field.dart';

--- a/lib/src/ui/widgets/questions/inputs/labeled_radio.dart
+++ b/lib/src/ui/widgets/questions/inputs/labeled_radio.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+class LabeledRadio<T> extends StatelessWidget {
+  const LabeledRadio({
+    @required this.onChanged,
+    @required this.value,
+    @required this.groupValue,
+    this.label,
+    this.semanticsLabel,
+    this.semanticsValue,
+    this.axis = Axis.horizontal,
+  }) : assert(axis != null);
+
+  final VoidCallback onChanged;
+  final T value;
+  final T groupValue;
+  final String label;
+  final String semanticsLabel;
+  final String semanticsValue;
+  final Axis axis;
+
+  Widget _wrapForOrientation({List<Widget> children}) {
+    switch (axis) {
+      case Axis.horizontal:
+        return Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: children);
+      case Axis.vertical:
+        return Column(children: children);
+    }
+    assert(false, 'Axis $axis not handled');
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _wrapForOrientation(
+      children: <Widget>[
+        Semantics(
+          explicitChildNodes: false,
+          label: semanticsLabel,
+          value: semanticsValue,
+          child: Radio<T>(
+            onChanged: (T value) => onChanged(),
+            value: value,
+            groupValue: groupValue,
+            activeColor: Theme.of(context).colorScheme.secondary,
+          ),
+        ),
+        ExcludeSemantics(
+          child: GestureDetector(
+            onTap: onChanged,
+            child: Text(label, style: Theme.of(context).textTheme.button),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
+++ b/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
@@ -8,79 +8,132 @@ class RadioButtonScale extends StatelessWidget {
     @required this.labels,
     @required this.semanticLabels,
     this.onChanged,
+    this.axis = Axis.horizontal,
   })  : assert(labels != null),
         assert(semanticLabels != null),
         assert(semanticLabels.length == labels.length),
+        assert(axis != null),
+        _isScale = labels.length > 2,
         super(key: key);
 
   final int value;
   final List<String> labels;
   final List<String> semanticLabels;
   final ValueChanged<int> onChanged;
+  final Axis axis;
+  final bool _isScale;
   bool get enabled => onChanged != null;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(10.0),
-      child: Stack(
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    switch (axis) {
+      case Axis.horizontal:
+        return Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Stack(
             children: <Widget>[
-              for (int index = 0; index < labels.length; ++index)
-                Expanded(
-                  flex: 2,
-                  child: Column(
-                    children: <Widget>[
-                      Semantics(
-                        explicitChildNodes: false,
-                        label: semanticLabels[index],
-                        value: '${index + 1}',
-                        child: Radio(
-                          onChanged: onChanged,
-                          value: index,
-                          groupValue: value,
-                          activeColor: Theme.of(context).colorScheme.secondary,
-                        ),
-                      ),
-                      ExcludeSemantics(
-                        child: Center(
-                          child: Text(
-                            labels[index],
-                            textAlign: TextAlign.center,
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  for (int index = 0; index < labels.length; ++index)
+                    Expanded(
+                      flex: 2,
+                      child: Column(
+                        children: <Widget>[
+                          Semantics(
+                            explicitChildNodes: false,
+                            label: semanticLabels[index],
+                            value: '${index + 1}',
+                            child: Radio<int>(
+                              onChanged: onChanged,
+                              value: index,
+                              groupValue: value,
+                              activeColor:
+                                  Theme.of(context).colorScheme.secondary,
+                            ),
                           ),
-                        ),
+                          ExcludeSemantics(
+                            child: Center(
+                              child: Text(
+                                labels[index],
+                                textAlign: TextAlign.center,
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
+                    ),
+                ],
+              ),
+              if (_isScale)
+                Positioned(
+                  top: 19,
+                  left: 0,
+                  right: 0,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Spacer(flex: 1),
+                      for (int index = 0; index < labels.length - 1; ++index)
+                        Expanded(
+                            flex: 2,
+                            child: Divider(
+                              height: 10,
+                              thickness: 5.0,
+                              endIndent: 14,
+                              indent: 14,
+                              color: Colors.black38,
+                            )),
+                      Spacer(flex: 1),
                     ],
                   ),
                 ),
             ],
           ),
-          Positioned(
-            top: 19,
-            left: 0,
-            right: 0,
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Spacer(flex: 1),
-                for (int index = 0; index < labels.length - 1; ++index)
-                  Expanded(
-                      flex: 2,
-                      child: Divider(
-                        height: 10,
-                        thickness: 5.0,
-                        endIndent: 14,
-                        indent: 14,
-                        color: Colors.black38,
-                      )),
-                Spacer(flex: 1),
-              ],
-            ),
+        );
+      case Axis.vertical:
+        return Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Stack(
+            children: <Widget>[
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  for (int index = 0; index < labels.length; ++index)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        Semantics(
+                          explicitChildNodes: false,
+                          label: semanticLabels[index],
+                          value: '${index + 1}',
+                          child: Radio<int>(
+                            onChanged: onChanged,
+                            value: index,
+                            groupValue: value,
+                            activeColor:
+                                Theme.of(context).colorScheme.secondary,
+                          ),
+                        ),
+                        ExcludeSemantics(
+                          child: Center(
+                            child: Text(
+                              labels[index],
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ],
           ),
-        ],
-      ),
-    );
+        );
+    }
+    assert(false, 'Axis $axis not handled.');
+    return null;
   }
 }

--- a/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
+++ b/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
@@ -1,145 +1,159 @@
+import 'package:covidnearme/src/ui/widgets/questions/inputs/labeled_radio.dart';
 import 'package:flutter/material.dart';
 
-@immutable
-class RadioButtonScale extends StatelessWidget {
-  const RadioButtonScale({
+abstract class RadioButtonScale extends StatelessWidget {
+  const RadioButtonScale._({Key key}) : super(key: key);
+
+  factory RadioButtonScale({
+    Key key,
+    int value,
+    @required List<String> labels,
+    @required List<String> semanticLabels,
+    ValueChanged<int> onChanged,
+    Axis axis = Axis.horizontal,
+  }) {
+    switch (axis) {
+      case Axis.horizontal:
+        return _HorizontalButtonScale(
+          key: key,
+          value: value,
+          labels: labels,
+          semanticLabels: semanticLabels,
+          onChanged: onChanged,
+        );
+      case Axis.vertical:
+        return _VerticalButtonScale(
+          key: key,
+          value: value,
+          labels: labels,
+          semanticLabels: semanticLabels,
+          onChanged: onChanged,
+        );
+    }
+    return null;
+  }
+
+  int get value;
+  List<String> get labels;
+  List<String> get semanticLabels;
+  ValueChanged<int> get onChanged;
+  bool get enabled => onChanged != null;
+}
+
+class _HorizontalButtonScale extends RadioButtonScale {
+  const _HorizontalButtonScale({
     Key key,
     this.value,
     @required this.labels,
     @required this.semanticLabels,
     this.onChanged,
-    this.axis = Axis.horizontal,
   })  : assert(labels != null),
         assert(semanticLabels != null),
         assert(semanticLabels.length == labels.length),
-        assert(axis != null),
         _isScale = labels.length > 2,
-        super(key: key);
+        super._(key: key);
 
   final int value;
   final List<String> labels;
   final List<String> semanticLabels;
   final ValueChanged<int> onChanged;
-  final Axis axis;
   final bool _isScale;
-  bool get enabled => onChanged != null;
 
   @override
   Widget build(BuildContext context) {
-    switch (axis) {
-      case Axis.horizontal:
-        return Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: Stack(
+    return Padding(
+      padding: const EdgeInsets.all(10.0),
+      child: Stack(
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  for (int index = 0; index < labels.length; ++index)
-                    Expanded(
-                      flex: 2,
-                      child: Column(
-                        children: <Widget>[
-                          Semantics(
-                            explicitChildNodes: false,
-                            label: semanticLabels[index],
-                            value: '${index + 1}',
-                            child: Radio<int>(
-                              onChanged: onChanged,
-                              value: index,
-                              groupValue: value,
-                              activeColor:
-                                  Theme.of(context).colorScheme.secondary,
-                            ),
-                          ),
-                          ExcludeSemantics(
-                            child: GestureDetector(
-                              onTap: () => onChanged(index),
-                              child: Center(
-                                child: Text(
-                                  labels[index],
-                                  textAlign: TextAlign.center,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                ],
-              ),
-              if (_isScale)
-                Positioned(
-                  top: 19,
-                  left: 0,
-                  right: 0,
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Spacer(flex: 1),
-                      for (int index = 0; index < labels.length - 1; ++index)
-                        Expanded(
-                            flex: 2,
-                            child: Divider(
-                              height: 10,
-                              thickness: 5.0,
-                              endIndent: 14,
-                              indent: 14,
-                              color: Colors.black38,
-                            )),
-                      Spacer(flex: 1),
-                    ],
+              for (int index = 0; index < labels.length; ++index)
+                Expanded(
+                  flex: 2,
+                  child: LabeledRadio(
+                    label: labels[index],
+                    semanticsLabel: semanticLabels[index],
+                    semanticsValue: '${index + 1}',
+                    onChanged: () => onChanged(index),
+                    value: index,
+                    groupValue: value,
+                    axis: Axis.vertical,
                   ),
                 ),
             ],
           ),
-        );
-      case Axis.vertical:
-        return Padding(
-          padding: const EdgeInsets.all(10.0),
-          child: Stack(
-            children: <Widget>[
-              Column(
-                mainAxisSize: MainAxisSize.min,
+          if (_isScale)
+            Positioned(
+              top: 19,
+              left: 0,
+              right: 0,
+              child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: <Widget>[
-                  for (int index = 0; index < labels.length; ++index)
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: <Widget>[
-                        Semantics(
-                          explicitChildNodes: false,
-                          label: semanticLabels[index],
-                          value: '${index + 1}',
-                          child: Radio<int>(
-                            onChanged: onChanged,
-                            value: index,
-                            groupValue: value,
-                            activeColor:
-                                Theme.of(context).colorScheme.secondary,
-                          ),
-                        ),
-                        ExcludeSemantics(
-                          child: GestureDetector(
-                            onTap: () => onChanged(index),
-                            child: Center(
-                              child: Text(
-                                labels[index],
-                                textAlign: TextAlign.center,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
+                  Spacer(flex: 1),
+                  for (int index = 0; index < labels.length - 1; ++index)
+                    Expanded(
+                        flex: 2,
+                        child: Divider(
+                          height: 10,
+                          thickness: 5.0,
+                          endIndent: 14,
+                          indent: 14,
+                          color: Colors.black38,
+                        )),
+                  Spacer(flex: 1),
                 ],
               ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _VerticalButtonScale extends RadioButtonScale {
+  const _VerticalButtonScale({
+    Key key,
+    this.value,
+    @required this.labels,
+    @required this.semanticLabels,
+    this.onChanged,
+  })  : assert(labels != null),
+        assert(semanticLabels != null),
+        assert(semanticLabels.length == labels.length),
+        super._(key: key);
+
+  final int value;
+  final List<String> labels;
+  final List<String> semanticLabels;
+  final ValueChanged<int> onChanged;
+  bool get enabled => onChanged != null;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(10.0),
+      child: Stack(
+        children: <Widget>[
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              for (int index = 0; index < labels.length; ++index)
+                LabeledRadio(
+                  label: labels[index],
+                  semanticsLabel: semanticLabels[index],
+                  semanticsValue: '${index + 1}',
+                  onChanged: () => onChanged(index),
+                  value: index,
+                  groupValue: value,
+                  axis: Axis.horizontal,
+                ),
             ],
           ),
-        );
-    }
-    assert(false, 'Axis $axis not handled.');
-    return null;
+        ],
+      ),
+    );
   }
 }

--- a/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
+++ b/lib/src/ui/widgets/questions/inputs/radio_button_scale.dart
@@ -53,10 +53,13 @@ class RadioButtonScale extends StatelessWidget {
                             ),
                           ),
                           ExcludeSemantics(
-                            child: Center(
-                              child: Text(
-                                labels[index],
-                                textAlign: TextAlign.center,
+                            child: GestureDetector(
+                              onTap: () => onChanged(index),
+                              child: Center(
+                                child: Text(
+                                  labels[index],
+                                  textAlign: TextAlign.center,
+                                ),
                               ),
                             ),
                           ),
@@ -118,10 +121,13 @@ class RadioButtonScale extends StatelessWidget {
                           ),
                         ),
                         ExcludeSemantics(
-                          child: Center(
-                            child: Text(
-                              labels[index],
-                              textAlign: TextAlign.center,
+                          child: GestureDetector(
+                            onTap: () => onChanged(index),
+                            child: Center(
+                              child: Text(
+                                labels[index],
+                                textAlign: TextAlign.center,
+                              ),
                             ),
                           ),
                         ),

--- a/lib/src/ui/widgets/questions/inputs/temperature_field.dart
+++ b/lib/src/ui/widgets/questions/inputs/temperature_field.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:covidnearme/src/ui/widgets/scroll_more_indicator.dart';
+import 'package:covidnearme/src/ui/widgets/tutorial_step.dart';
+
+import 'entry_field.dart';
+
+@immutable
+class TemperatureField extends StatefulWidget {
+  TemperatureField({
+    Key key,
+    this.initialValue,
+    this.onChanged,
+    this.label,
+    this.helperText,
+    this.minHeight = 100,
+    this.autofocus = false,
+  })  : assert(autofocus != null),
+        super(key: key);
+
+  final double initialValue;
+  final String helperText;
+
+  // Always returns values in fahrenheit.
+  final ValueChanged<double> onChanged;
+
+  final String label;
+  final double minHeight;
+  final bool autofocus;
+
+  @override
+  _TemperatureFieldState createState() => _TemperatureFieldState();
+}
+
+class _TemperatureFieldState extends State<TemperatureField> {
+  static const double _celsiusMax = 65.5;
+  static const double _celsiusMin = 21.1;
+  static const double _fahrenheitMax = 150.0;
+  static const double _fahrenheitMin = 70.0;
+
+  bool get _isCelsius =>
+      _degrees != null && _degrees <= _celsiusMax && _degrees >= _celsiusMin;
+
+  bool get _isFahrenheit =>
+      _degrees != null &&
+      _degrees <= _fahrenheitMax &&
+      _degrees >= _fahrenheitMin;
+
+  bool get _isValid => _degrees != null && (_isCelsius || _isFahrenheit);
+
+  double _degrees;
+  double _reportedDegrees;
+
+  @override
+  void initState() {
+    super.initState();
+    _degrees = widget.initialValue;
+  }
+
+  double _toFahrenheit(double value) {
+    if (_isFahrenheit) return value;
+    return value * (9.0 / 5.0) + 32.0;
+  }
+
+  String _validateTemperature(String value, AppLocalizations localizations) {
+    if (value.isNotEmpty) {
+      final double degrees = double.parse(value);
+      if (degrees < _celsiusMin ||
+          degrees > _fahrenheitMax ||
+          (degrees < _fahrenheitMin && degrees > _celsiusMax)) {
+        return localizations.temperatureStepTemperatureOutOfRangeError;
+      }
+    }
+    return null;
+  }
+
+  void _onChanged(String value) {
+    final double degrees = double.parse(value);
+    if (_degrees == degrees) {
+      return;
+    }
+    setState(() {
+      _degrees = degrees;
+    });
+    if (!_isValid || _degrees == _reportedDegrees) {
+      return;
+    }
+    _reportedDegrees = degrees;
+    widget.onChanged?.call(_toFahrenheit(_reportedDegrees));
+  }
+
+  Future<void> _showInstructions(BuildContext context) async {
+    final categoryFontStyle = TextStyle(
+      color: Theme.of(context).primaryColor,
+      fontWeight: FontWeight.bold,
+      fontSize: 18,
+    );
+
+    ScrollController controller = ScrollController();
+
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) {
+        final AppLocalizations localizations = AppLocalizations.of(context);
+        final ThemeData theme = Theme.of(context);
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(
+              localizations.temperatureStepHowToDialogTitle,
+              style: theme.textTheme.headline
+                  .copyWith(color: theme.colorScheme.onBackground),
+              textAlign: TextAlign.center,
+            ),
+          ),
+          body: ScrollMoreIndicator(
+            controller: controller,
+            child: ListView(
+              controller: controller,
+              padding: EdgeInsets.all(20),
+              children: <Widget>[
+                Text(
+                  localizations.temperatureStepWhenHeading,
+                  style: categoryFontStyle,
+                ),
+                SizedBox(height: 10),
+                _InstructionStep(
+                  text: localizations.temperatureStepWait30Minutes,
+                  number: 1,
+                ),
+                _InstructionStep(
+                  text: localizations.temperatureStepWait6Hours,
+                  number: 2,
+                ),
+                Text(
+                  localizations.temperatureStepHowHeading,
+                  style: categoryFontStyle,
+                ),
+                SizedBox(height: 10),
+                _InstructionStep(
+                  text: localizations.temperatureStepHowToDialogStep1,
+                  number: 1,
+                ),
+                _InstructionStep(
+                  text: localizations.temperatureStepHowToDialogStep2,
+                  number: 2,
+                ),
+                _InstructionStep(
+                  text: localizations.temperatureStepHowToDialogStep3,
+                  number: 3,
+                ),
+                _InstructionStep(
+                  text: localizations.temperatureStepHowToDialogStep4,
+                  number: 4,
+                ),
+                _InstructionStep(
+                  text: localizations.temperatureStepHowToDialogStep5,
+                  number: 5,
+                ),
+                Container(
+                  margin: EdgeInsets.only(top: 20),
+                  child: Center(
+                    child: RaisedButton(
+                      onPressed: () => Navigator.pop(context),
+                      child:
+                          Text(localizations.temperatureStepHowToDialogReturn),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Expanded(
+          flex: 1,
+          child: EntryField(
+            initialValue: widget.initialValue?.toStringAsFixed(1),
+            onChanged: _onChanged,
+            label: widget.label,
+            suffix: _isValid ? (_isCelsius ? '℃' : '℉') : null,
+            keyboardType: TextInputType.number,
+            inputFormatters: [
+              WhitelistingTextInputFormatter(RegExp(r'^\d+\.?\d?$')),
+            ],
+            minHeight: widget.minHeight,
+            autofocus: widget.autofocus,
+            validator: (String value) =>
+                _validateTemperature(value, localizations),
+          ),
+        ),
+        Expanded(
+          flex: 1,
+          child: Padding(
+            padding: const EdgeInsetsDirectional.only(start: 10.0),
+            child: RaisedButton(
+              onPressed: () => _showInstructions(context),
+              child: Text(localizations.temperatureStepHelp),
+              padding: EdgeInsets.symmetric(horizontal: 10, vertical: 8.0),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InstructionStep extends StatelessWidget {
+  const _InstructionStep({Key key, this.text, this.number}) : super(key: key);
+
+  final String text;
+  final int number;
+
+  @override
+  Widget build(BuildContext context) {
+    return TutorialStep(
+      text: text,
+      number: number,
+      fontSize: 16.0,
+      leadingBackgroundColor: Theme.of(context).colorScheme.secondary,
+      numberColor: Theme.of(context).colorScheme.onSecondary,
+    );
+  }
+}

--- a/lib/src/ui/widgets/questions/question_item.dart
+++ b/lib/src/ui/widgets/questions/question_item.dart
@@ -1,3 +1,5 @@
+import 'package:covidnearme/src/ui/widgets/questions/inputs/entry_field.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/temperature_field.dart';
 import 'package:flutter/material.dart';
 
 import 'package:covidnearme/src/data/models/questions.dart';
@@ -5,16 +7,19 @@ import 'package:covidnearme/src/ui/widgets/questions/inputs/radio_button_scale.d
 
 class QuestionItem extends StatefulWidget {
   final Question question;
-  final ValueChanged<int> onChanged;
+  final Function onChanged;
 
-  const QuestionItem({this.question, this.onChanged});
+  const QuestionItem({
+    @required this.question,
+    @required this.onChanged,
+  }) : assert(onChanged != null);
 
   @override
   _QuestionItemState createState() => _QuestionItemState();
 }
 
 class _QuestionItemState extends State<QuestionItem> {
-  int currentValue;
+  dynamic currentValue;
 
   @override
   void initState() {
@@ -31,16 +36,52 @@ class _QuestionItemState extends State<QuestionItem> {
     });
   }
 
+  void _handleTextChange(String value) {
+    setState(() {
+      currentValue = value;
+      widget.onChanged?.call(value as dynamic);
+    });
+  }
+
+  void _handleTemperatureChange(double value) {
+    setState(() {
+      currentValue = value;
+      widget.onChanged?.call(value as dynamic);
+    });
+  }
+
   Widget _getInput() {
     switch (widget.question.runtimeType) {
       case ScaleQuestion:
-        final ScaleQuestion sliderQuestion = widget.question;
+        final ScaleQuestion scaleQuestion = widget.question;
         return RadioButtonScale(
-          labels: sliderQuestion.labels,
-          value: currentValue,
-          semanticLabels: sliderQuestion.semanticLabels,
-          onChanged: widget.onChanged == null ? null : _handleRadioChange,
+          labels: scaleQuestion.labels,
+          axis: scaleQuestion.vertical ? Axis.vertical : Axis.horizontal,
+          value: currentValue as int,
+          semanticLabels: scaleQuestion.semanticLabels,
+          onChanged: _handleRadioChange,
         );
+        break;
+      case TemperatureQuestion:
+        final TemperatureQuestion temperatureQuestion = widget.question;
+        return Padding(
+          padding: const EdgeInsets.only(top: 20.0),
+          child: TemperatureField(
+            initialValue: temperatureQuestion.initialValue,
+            onChanged: _handleTemperatureChange,
+          ),
+        );
+        break;
+      case TextFieldQuestion:
+        final TextFieldQuestion textFieldQuestion = widget.question;
+        return Padding(
+          padding: const EdgeInsets.only(top: 20.0),
+          child: EntryField(
+            initialValue: textFieldQuestion.initialValue,
+            onChanged: _handleTextChange,
+          ),
+        );
+        break;
       default:
         return Container();
     }

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -32,15 +32,37 @@ class _QuestionViewState extends State<QuestionView> {
   Set<Question> _answered = {};
 
   List<Widget> _getQuestions() {
-    return widget.questions
-        .map((Question question) => QuestionItem(
-              question: question,
-              onChanged: (dynamic value) {
-                _answered.add(question);
-                return widget.onChange(question, value);
-              },
-            ))
-        .toList();
+    return widget.questions.map((Question question) {
+      switch (question.runtimeType) {
+        case ScaleQuestion:
+          return QuestionItem(
+            question: question,
+            onChanged: (int value) {
+              _answered.add(question);
+              return widget.onChange?.call(question, value);
+            },
+          );
+        case TextFieldQuestion:
+          return QuestionItem(
+            question: question,
+            onChanged: (String value) {
+              _answered.add(question);
+              return widget.onChange?.call(question, value);
+            },
+          );
+          break;
+        case TemperatureQuestion:
+          return QuestionItem(
+            question: question,
+            onChanged: (double value) {
+              _answered.add(question);
+              return widget.onChange?.call(question, value);
+            },
+          );
+          break;
+      }
+      return Container();
+    }).toList();
   }
 
   bool get _allQuestionsAnswered {

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -65,10 +65,6 @@ class _QuestionViewState extends State<QuestionView> {
     }).toList();
   }
 
-  bool get _allQuestionsAnswered {
-    return widget.questions.toSet().difference(_answered).isEmpty;
-  }
-
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -79,7 +75,7 @@ class _QuestionViewState extends State<QuestionView> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             ..._getQuestions(),
-            StepFinishedButton(validated: _allQuestionsAnswered),
+            StepFinishedButton(validated: true),
             SizedBox(height: 20),
           ],
         ),

--- a/lib/src/ui/widgets/questions/step_finished_button.dart
+++ b/lib/src/ui/widgets/questions/step_finished_button.dart
@@ -43,7 +43,9 @@ class StepFinishedButton extends StatelessWidget {
             onPressed: validated
                 ? () {
                     if (isLastStep) {
-                      context.bloc<SymptomReportBloc>().add(CompleteSymptomReport());
+                      context
+                          .bloc<SymptomReportBloc>()
+                          .add(CompleteSymptomReport());
                     } else {
                       Provider.of<PageController>(context, listen: false)
                           .nextPage(

--- a/test/ui/widgets/questions_test.dart
+++ b/test/ui/widgets/questions_test.dart
@@ -54,7 +54,10 @@ void main() {
 
     expect(find.text('subtitle'), findsOneWidget);
     expect(find.text('title'), findsOneWidget);
-    expect(find.byType(RadioButtonScale), findsOneWidget);
+    expect(
+        find.byWidgetPredicate((Widget widget) =>
+            widget.runtimeType.toString() == '_HorizontalButtonScale'),
+        findsOneWidget);
 
     expect(
       tester.getSemantics(find.bySemanticsLabel('one')),
@@ -108,7 +111,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      (tester.widget(find.byType(RadioButtonScale)) as RadioButtonScale).value,
+      (tester.widget(find.byWidgetPredicate((Widget widget) =>
+                  widget.runtimeType.toString() == '_HorizontalButtonScale'))
+              as RadioButtonScale)
+          .value,
       equals(1),
     );
     expect(

--- a/test/ui/widgets/questions_test.dart
+++ b/test/ui/widgets/questions_test.dart
@@ -21,6 +21,7 @@ void main() {
       Directionality(
         child: QuestionItem(
           question: FakeQuestion(),
+          onChanged: (dynamic value) {},
         ),
         textDirection: TextDirection.ltr,
       ),
@@ -40,6 +41,7 @@ void main() {
         QuestionItem(
           onChanged: (int value) {},
           question: ScaleQuestion(
+            id: '0',
             title: 'title',
             subtitle: 'subtitle',
             initialValue: 0,


### PR DESCRIPTION
Add the remaining questions in the questionnaire.

To do this, I had to add two new types of questions: a "text field" question, and a "temperature" question.

The first one is just a text field with the question text, and the temperature question has the auto-unit-sensing code, along with a button for popping up the "how to take your temperature" guide.

I now use the `TemperatureField` on the temperature page, as well as for the question "How high did your temperature get today (if you took it)?"

Looks like this:
![Screenshot_1585609887](https://user-images.githubusercontent.com/8867023/77970691-ae6e8080-72a1-11ea-98d1-fd71263d8117.png)

![Screenshot_1585610061](https://user-images.githubusercontent.com/8867023/77970697-b1697100-72a1-11ea-864f-7cddcd97f9a3.png)
