### PR TITLE
Add composite questions for progressive reveal

### DIFF
--- a/lib/src/data/models/questions.dart
+++ b/lib/src/data/models/questions.dart
@@ -44,7 +44,7 @@ class CompositeQuestion extends Question {
   final List<Question> children;
   // A list of answers, matching the answer needed for the previous question to
   // reveal the next.
-  // There must be one less than the number of questions.
+  // There must be one fewer answer than the number of questions.
   final List<dynamic> answers;
 
   factory CompositeQuestion.fromJson(Map<String, dynamic> json) {

--- a/lib/src/data/models/questions.dart
+++ b/lib/src/data/models/questions.dart
@@ -4,17 +4,11 @@ import 'package:meta/meta.dart';
 part 'questions.g.dart';
 
 abstract class Question {
-  final String id;
-  final String title;
-  final String subtitle;
+  const Question();
 
-  Question({
-    @required this.id,
-    @required this.title,
-    this.subtitle,
-  })  : assert(id != null),
-        assert(title != null),
-        assert(title.isNotEmpty);
+  String get id;
+  String get title;
+  String get subtitle;
 
   factory Question.fromJson(Map<String, dynamic> json) {
     switch (json['type']) {
@@ -24,11 +18,62 @@ abstract class Question {
         return TextFieldQuestion.fromJson(json);
       case TemperatureQuestion.TYPE:
         return TemperatureQuestion.fromJson(json);
+      case CompositeQuestion.TYPE:
+        return CompositeQuestion.fromJson(json);
       default:
         return UnknownQuestion.fromJson(json);
     }
   }
   Map<String, dynamic> toJson() => throw UnimplementedError();
+}
+
+class CompositeQuestion extends Question {
+  static const TYPE = 'composite';
+
+  CompositeQuestion({
+    @required this.children,
+    @required this.answers,
+  })  : assert(children != null),
+        assert(children.isNotEmpty),
+        assert(answers.length == children.length - 1);
+
+  String get id => children[0].id;
+  String get title => children[0].title;
+  String get subtitle => children[0].subtitle;
+
+  final List<Question> children;
+  // A list of answers, matching the answer needed for the previous question to
+  // reveal the next.
+  // There must be one less than the number of questions.
+  final List<dynamic> answers;
+
+  factory CompositeQuestion.fromJson(Map<String, dynamic> json) {
+    List<Question> children = <Question>[];
+    List<dynamic> answers = <String>[];
+    int childCount = json['num_children'];
+    for (int i = 0; i < childCount; ++i) {
+      children.add(Question.fromJson(json['child_$i']));
+      if (i < childCount - 1) {
+        answers.add(json['answer_$i']);
+      }
+    }
+    return CompositeQuestion(
+      children: children,
+      answers: answers,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> json = {'type': TYPE};
+    json['num_children'] = children.length;
+    for (int i = 0; i < children.length; ++i) {
+      json['child_$i'] = children[i].toJson();
+    }
+    json['id'] = '';
+    json['title'] = '';
+    json['subtitle'] = '';
+    return json;
+  }
 }
 
 // Returns null if the input value is valid, and a localized error string if it
@@ -39,18 +84,19 @@ typedef TextFieldQuestionValidator = String Function(String value);
 class TextFieldQuestion extends Question {
   static const TYPE = 'text_field';
 
+  final String id;
+  final String title;
+  final String subtitle;
   final String initialValue;
 
   TextFieldQuestion({
-    @required String id,
-    @required String title,
-    String subtitle,
+    @required this.id,
+    @required this.title,
+    this.subtitle,
     this.initialValue,
-  }) : super(
-          id: id,
-          title: title,
-          subtitle: subtitle,
-        );
+  })  : assert(id != null),
+        assert(title != null),
+        assert(title.isNotEmpty);
 
   factory TextFieldQuestion.fromJson(Map<String, dynamic> json) =>
       _$TextFieldQuestionFromJson(json);
@@ -65,18 +111,19 @@ class TextFieldQuestion extends Question {
 class TemperatureQuestion extends Question {
   static const TYPE = 'temperature';
 
+  final String id;
+  final String title;
+  final String subtitle;
   final double initialValue;
 
   TemperatureQuestion({
-    @required String id,
-    @required String title,
-    String subtitle,
+    @required this.id,
+    @required this.title,
+    this.subtitle,
     this.initialValue,
-  }) : super(
-          id: id,
-          title: title,
-          subtitle: subtitle,
-        );
+  })  : assert(id != null),
+        assert(title != null),
+        assert(title.isNotEmpty);
 
   factory TemperatureQuestion.fromJson(Map<String, dynamic> json) =>
       _$TemperatureQuestionFromJson(json);
@@ -91,27 +138,28 @@ class TemperatureQuestion extends Question {
 class ScaleQuestion extends Question {
   static const TYPE = 'scale';
 
+  final String id;
+  final String title;
+  final String subtitle;
   final int initialValue;
   final List<String> labels;
   final List<String> semanticLabels;
   final bool vertical;
 
   ScaleQuestion({
-    @required String id,
-    @required String title,
-    String subtitle,
+    @required this.id,
+    @required this.title,
+    this.subtitle,
     this.initialValue,
     @required this.labels,
     @required this.semanticLabels,
     this.vertical = false,
-  })  : assert(labels != null),
+  })  : assert(id != null),
+        assert(title != null),
+        assert(title.isNotEmpty),
+        assert(labels != null),
         assert(semanticLabels != null),
-        assert(vertical != null),
-        super(
-          id: id,
-          title: title,
-          subtitle: subtitle,
-        );
+        assert(vertical != null);
 
   factory ScaleQuestion.fromJson(Map<String, dynamic> json) =>
       _$ScaleQuestionFromJson(json);
@@ -126,16 +174,13 @@ class ScaleQuestion extends Question {
 class UnknownQuestion extends Question {
   final String type;
 
+  String get id => 'unknown';
+  String get title => 'unknown title';
+  String get subtitle => 'unknown subtitle';
+
   UnknownQuestion({
-    @required id,
-    @required title,
-    subtitle,
-    this.type,
-  }) : super(
-          id: id,
-          title: title,
-          subtitle: subtitle,
-        );
+    @required this.type,
+  });
 
   factory UnknownQuestion.fromJson(Map<String, dynamic> json) =>
       _$UnknownQuestionFromJson(json);

--- a/lib/src/data/models/questions.g.dart
+++ b/lib/src/data/models/questions.g.dart
@@ -67,17 +67,11 @@ Map<String, dynamic> _$ScaleQuestionToJson(ScaleQuestion instance) =>
 
 UnknownQuestion _$UnknownQuestionFromJson(Map<String, dynamic> json) {
   return UnknownQuestion(
-    id: json['id'],
-    title: json['title'],
-    subtitle: json['subtitle'],
     type: json['type'] as String,
   );
 }
 
 Map<String, dynamic> _$UnknownQuestionToJson(UnknownQuestion instance) =>
     <String, dynamic>{
-      'id': instance.id,
-      'title': instance.title,
-      'subtitle': instance.subtitle,
       'type': instance.type,
     };

--- a/lib/src/data/repositories/questions.dart
+++ b/lib/src/data/repositories/questions.dart
@@ -78,74 +78,84 @@ class QuestionsRepository {
             localizations.questionHaveNauseaSemantics3,
           ],
         ),
-        ScaleQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '2',
-          title: localizations.questionHaveYouBeenFluTestedTitle,
-          initialValue: null,
-          labels: [
-            localizations.questionNo,
-            localizations.questionYes,
+        CompositeQuestion(
+          children: <Question>[
+            ScaleQuestion(
+              // TODO(gspencergoog): Insert correct ID here.
+              id: '2',
+              title: localizations.questionHaveYouBeenFluTestedTitle,
+              initialValue: null,
+              labels: [
+                localizations.questionNo,
+                localizations.questionYes,
+              ],
+              semanticLabels: [
+                localizations.questionHaveAFeverSemantics1,
+                localizations.questionHaveAFeverSemantics0,
+              ],
+            ),
+            ScaleQuestion(
+              // TODO(gspencergoog): Insert correct ID here.
+              id: '3',
+              title: localizations.questionFluTestPositiveTitle,
+              initialValue: null,
+              labels: [
+                localizations.questionNo,
+                localizations.questionYes,
+              ],
+              semanticLabels: [
+                localizations.questionFluTestPositiveSemantics1,
+                localizations.questionFluTestPositiveSemantics0,
+              ],
+            ),
+            TextFieldQuestion(
+              // TODO(gspencergoog): Insert correct ID here.
+              id: '4',
+              title: localizations.questionWhatWasPositiveTitle,
+              initialValue: null,
+            ),
           ],
-          semanticLabels: [
-            localizations.questionHaveAFeverSemantics1,
-            localizations.questionHaveAFeverSemantics0,
-          ],
+          answers: <dynamic>[1, 1],
         ),
-        ScaleQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '2',
-          title: localizations.questionFluTestPositiveTitle,
-          initialValue: null,
-          labels: [
-            localizations.questionNo,
-            localizations.questionYes,
+        CompositeQuestion(
+          children: <Question>[
+            ScaleQuestion(
+              // TODO(gspencergoog): Insert correct ID here.
+              id: '5',
+              title: localizations.questionTryForTestingTitle,
+              initialValue: null,
+              labels: [
+                localizations.questionNo,
+                localizations.questionYes,
+              ],
+              semanticLabels: [
+                localizations.questionTryForTestingSemantics1,
+                localizations.questionTryForTestingSemantics0,
+              ],
+            ),
+            ScaleQuestion(
+              // TODO(gspencergoog): Insert correct ID here.
+              id: '6',
+              title: localizations.questionCovid19TestResultTitle,
+              vertical: true,
+              initialValue: null,
+              labels: [
+                localizations.questionCovid19TestResultAnswer0,
+                localizations.questionCovid19TestResultAnswer1,
+                localizations.questionCovid19TestResultAnswer2,
+                localizations.questionCovid19TestResultAnswer3,
+                localizations.questionCovid19TestResultAnswer4,
+              ],
+              semanticLabels: [
+                localizations.questionCovid19TestResultAnswer0,
+                localizations.questionCovid19TestResultAnswer1,
+                localizations.questionCovid19TestResultAnswer2,
+                localizations.questionCovid19TestResultAnswer3,
+                localizations.questionCovid19TestResultAnswer4,
+              ],
+            ),
           ],
-          semanticLabels: [
-            localizations.questionFluTestPositiveSemantics1,
-            localizations.questionFluTestPositiveSemantics0,
-          ],
-        ),
-        TextFieldQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '3',
-          title: localizations.questionWhatWasPositiveTitle,
-          initialValue: null,
-        ),
-        ScaleQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '4',
-          title: localizations.questionTryForTestingTitle,
-          initialValue: null,
-          labels: [
-            localizations.questionNo,
-            localizations.questionYes,
-          ],
-          semanticLabels: [
-            localizations.questionTryForTestingSemantics1,
-            localizations.questionTryForTestingSemantics0,
-          ],
-        ),
-        ScaleQuestion(
-          // TODO(gspencergoog): Insert correct ID here.
-          id: '4',
-          title: localizations.questionCovid19TestResultTitle,
-          vertical: true,
-          initialValue: null,
-          labels: [
-            localizations.questionCovid19TestResultAnswer0,
-            localizations.questionCovid19TestResultAnswer1,
-            localizations.questionCovid19TestResultAnswer2,
-            localizations.questionCovid19TestResultAnswer3,
-            localizations.questionCovid19TestResultAnswer4,
-          ],
-          semanticLabels: [
-            localizations.questionCovid19TestResultAnswer0,
-            localizations.questionCovid19TestResultAnswer1,
-            localizations.questionCovid19TestResultAnswer2,
-            localizations.questionCovid19TestResultAnswer3,
-            localizations.questionCovid19TestResultAnswer4,
-          ],
+          answers: <dynamic>[1],
         ),
       ];
 }

--- a/lib/src/ui/screens/symptom_report/steps/subjective.dart
+++ b/lib/src/ui/screens/symptom_report/steps/subjective.dart
@@ -32,17 +32,21 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
         );
 
         // Check if we have an existing response
-        final int existingResponseIndex =
-            symptomReport.questionResponses.indexWhere(
-          (QuestionResponse response) =>
-              response.questionId == newResponse.questionId,
+        final int existingResponseIndex = symptomReport.questionResponses.indexWhere(
+          (QuestionResponse response) => response.questionId == newResponse.questionId,
         );
 
         // Replace or add the new response
         if (existingResponseIndex != -1) {
-          symptomReport.questionResponses[existingResponseIndex] = newResponse;
+          if (value == null) {
+            symptomReport.questionResponses.removeAt(existingResponseIndex);
+          } else {
+            symptomReport.questionResponses[existingResponseIndex] = newResponse;
+          }
         } else {
-          symptomReport.questionResponses.add(newResponse);
+          if (value != null) {
+            symptomReport.questionResponses.add(newResponse);
+          }
         }
 
         return symptomReport;
@@ -56,8 +60,7 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
       builder: (context, state) {
         if (state is! QuestionsStateLoaded) {
           return Container(
-            child: Text(AppLocalizations.of(context)
-                .subjectiveStepQuestionsLoadedError),
+            child: Text(AppLocalizations.of(context).subjectiveStepQuestionsLoadedError),
           );
         }
 

--- a/lib/src/ui/widgets/questions/question_item.dart
+++ b/lib/src/ui/widgets/questions/question_item.dart
@@ -12,9 +12,11 @@ class QuestionItem<T> extends StatefulWidget {
   final QuestionItemChanged<T> onChanged;
 
   const QuestionItem({
+    Key key,
     @required this.question,
     @required this.onChanged,
-  }) : assert(onChanged != null);
+  })  : assert(onChanged != null),
+        super(key: key);
 
   @override
   _QuestionItemState<T> createState() => _QuestionItemState<T>();

--- a/lib/src/ui/widgets/questions/question_item.dart
+++ b/lib/src/ui/widgets/questions/question_item.dart
@@ -17,10 +17,10 @@ class QuestionItem<T> extends StatefulWidget {
   }) : assert(onChanged != null);
 
   @override
-  _QuestionItemState createState() => _QuestionItemState();
+  _QuestionItemState<T> createState() => _QuestionItemState<T>();
 }
 
-class _QuestionItemState extends State<QuestionItem> {
+class _QuestionItemState<T> extends State<QuestionItem<T>> {
   dynamic currentValue;
 
   @override
@@ -31,24 +31,10 @@ class _QuestionItemState extends State<QuestionItem> {
     }
   }
 
-  void _handleRadioChange(int value) {
+  void _handleChange(dynamic value) {
     setState(() {
       currentValue = value;
-      widget.onChanged?.call(value);
-    });
-  }
-
-  void _handleTextChange(String value) {
-    setState(() {
-      currentValue = value;
-      widget.onChanged?.call(value as dynamic);
-    });
-  }
-
-  void _handleTemperatureChange(double value) {
-    setState(() {
-      currentValue = value;
-      widget.onChanged?.call(value as dynamic);
+      widget.onChanged?.call(value as T);
     });
   }
 
@@ -61,7 +47,7 @@ class _QuestionItemState extends State<QuestionItem> {
           axis: scaleQuestion.vertical ? Axis.vertical : Axis.horizontal,
           value: currentValue as int,
           semanticLabels: scaleQuestion.semanticLabels,
-          onChanged: _handleRadioChange,
+          onChanged: _handleChange,
         );
         break;
       case TemperatureQuestion:
@@ -70,7 +56,7 @@ class _QuestionItemState extends State<QuestionItem> {
           padding: const EdgeInsets.only(top: 20.0),
           child: TemperatureField(
             initialValue: temperatureQuestion.initialValue,
-            onChanged: _handleTemperatureChange,
+            onChanged: _handleChange,
           ),
         );
         break;
@@ -80,7 +66,7 @@ class _QuestionItemState extends State<QuestionItem> {
           padding: const EdgeInsets.only(top: 20.0),
           child: EntryField(
             initialValue: textFieldQuestion.initialValue,
-            onChanged: _handleTextChange,
+            onChanged: _handleChange,
           ),
         );
         break;

--- a/lib/src/ui/widgets/questions/question_item.dart
+++ b/lib/src/ui/widgets/questions/question_item.dart
@@ -5,9 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:covidnearme/src/data/models/questions.dart';
 import 'package:covidnearme/src/ui/widgets/questions/inputs/radio_button_scale.dart';
 
-class QuestionItem extends StatefulWidget {
+typedef QuestionItemChanged<T> = void Function(T value);
+
+class QuestionItem<T> extends StatefulWidget {
   final Question question;
-  final Function onChanged;
+  final QuestionItemChanged<T> onChanged;
 
   const QuestionItem({
     @required this.question,

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -43,18 +43,21 @@ class _QuestionViewState extends State<QuestionView> {
       switch (question.runtimeType) {
         case ScaleQuestion:
           yield QuestionItem<int>(
+            key: ValueKey<Question>(question),
             question: question,
             onChanged: (int value) => onChanged(question, value),
           );
           break;
         case TextFieldQuestion:
           yield QuestionItem<String>(
+            key: ValueKey<Question>(question),
             question: question,
             onChanged: (String value) => onChanged(question, value),
           );
           break;
         case TemperatureQuestion:
           yield QuestionItem<double>(
+            key: ValueKey<Question>(question),
             question: question,
             onChanged: (double value) => onChanged(question, value),
           );
@@ -62,18 +65,29 @@ class _QuestionViewState extends State<QuestionView> {
         case CompositeQuestion:
           CompositeQuestion composite = question;
           yield QuestionItem<dynamic>(
+            key: ValueKey<Question>(composite.children.first),
             question: composite.children.first,
             onChanged: (dynamic value) =>
                 onChanged(composite.children.first, value),
           );
+          bool endReached = false;
           for (int i = 1; i < composite.children.length; ++i) {
-            if (_answered[composite.children[i - 1]] ==
-                composite.answers[i - 1]) {
+            final Question child = composite.children[i];
+            if (!endReached &&
+                _answered[composite.children[i - 1]] ==
+                    composite.answers[i - 1]) {
               yield QuestionItem<dynamic>(
-                question: composite.children[i],
+                key: ValueKey<Question>(child),
+                question: child,
                 onChanged: (dynamic value) =>
-                    onChanged(composite.children[i], value),
+                    onChanged(child, value),
               );
+            } else {
+              endReached = true;
+              // Remove any answers for questions that no longer apply.
+              if (_answered.remove(child) != null) {
+                onChanged(child, null);
+              }
             }
           }
           break;

--- a/test/ui/widgets/questions_test.dart
+++ b/test/ui/widgets/questions_test.dart
@@ -19,7 +19,7 @@ void main() {
       (tester) async {
     await tester.pumpWidget(
       Directionality(
-        child: QuestionItem(
+        child: QuestionItem<dynamic>(
           question: FakeQuestion(),
           onChanged: (dynamic value) {},
         ),


### PR DESCRIPTION
It seemed to me that some of the questions were set up to follow on from previous questions, so I tried out something: what if those questions would progressively reveal when you answered the previous question?

This is the result of that.  Not sure if it's the right thing or not, but it seems good to me. Please try it out and see what you think.

For instance, if you select "Yes" here for the Flu test question:
![Screenshot_1585647700](https://user-images.githubusercontent.com/8867023/78012021-40ee3e80-72f9-11ea-856a-9ee06f13ab87.png)

It switches to include the "Was the test positive?" question:
![Screenshot_1585647704](https://user-images.githubusercontent.com/8867023/78012031-4481c580-72f9-11ea-81bb-85277d4ebe68.png)

And then the "What did you have?" question:
![Screenshot_1585647712](https://user-images.githubusercontent.com/8867023/78012041-477cb600-72f9-11ea-8d87-25c0fca063ba.png)
