### PR TITLE
Make case consistent on buttons.

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -216,7 +216,7 @@
     "description": "Title that appears within the textfield where the user enters their temperature"
   },
 
-  "temperatureStepHelp": "How to check your temperature",
+  "temperatureStepHelp": "HOW TO TAKE YOUR TEMPERATURE",
   "@temperatureStepHelp": {
     "description": "Label for a button that brings up a help screen"
   },
@@ -291,7 +291,7 @@
     "description": "Tell a user that has already completed their checkup that they can check again tomorrow"
   },
 
-  "homeScreenViewMyAssessment": "View my assessment",
+  "homeScreenViewMyAssessment": "VIEW MY ASSESSMENT",
   "@homeScreenViewMyAssessment": {
     "description": "View the assessment of the checkup data"
   },

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -181,7 +181,7 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get temperatureStepInputLabel => 'Enter your temperature';
 
   @override
-  String get temperatureStepHelp => 'How to check your temperature';
+  String get temperatureStepHelp => 'HOW TO TAKE YOUR TEMPERATURE';
 
   @override
   String get locationStepTitle => 'Enter your location';
@@ -228,7 +228,7 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
       'If you continue to experience symptoms, please check back tomorrow.';
 
   @override
-  String get homeScreenViewMyAssessment => 'View my assessment';
+  String get homeScreenViewMyAssessment => 'VIEW MY ASSESSMENT';
 
   @override
   String get shareAppDownloadPrompt =>

--- a/lib/src/ui/screens/symptom_report/steps/subjective.dart
+++ b/lib/src/ui/screens/symptom_report/steps/subjective.dart
@@ -32,8 +32,10 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
         );
 
         // Check if we have an existing response
-        final int existingResponseIndex = symptomReport.questionResponses.indexWhere(
-          (QuestionResponse response) => response.questionId == newResponse.questionId,
+        final int existingResponseIndex =
+            symptomReport.questionResponses.indexWhere(
+          (QuestionResponse response) =>
+              response.questionId == newResponse.questionId,
         );
 
         // Replace or add the new response
@@ -41,7 +43,8 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
           if (value == null) {
             symptomReport.questionResponses.removeAt(existingResponseIndex);
           } else {
-            symptomReport.questionResponses[existingResponseIndex] = newResponse;
+            symptomReport.questionResponses[existingResponseIndex] =
+                newResponse;
           }
         } else {
           if (value != null) {
@@ -60,7 +63,8 @@ class _SubjectiveStepState extends State<SubjectiveStep> {
       builder: (context, state) {
         if (state is! QuestionsStateLoaded) {
           return Container(
-            child: Text(AppLocalizations.of(context).subjectiveStepQuestionsLoadedError),
+            child: Text(AppLocalizations.of(context)
+                .subjectiveStepQuestionsLoadedError),
           );
         }
 

--- a/lib/src/ui/widgets/questions/question_view.dart
+++ b/lib/src/ui/widgets/questions/question_view.dart
@@ -79,8 +79,7 @@ class _QuestionViewState extends State<QuestionView> {
               yield QuestionItem<dynamic>(
                 key: ValueKey<Question>(child),
                 question: child,
-                onChanged: (dynamic value) =>
-                    onChanged(child, value),
+                onChanged: (dynamic value) => onChanged(child, value),
               );
             } else {
               endReached = true;


### PR DESCRIPTION
There were a few buttons which were still using sentence case on them, and I modified them to be all uppercase, in line with Material recommendations.

This should make things consistent, and I think that satisfies the intent of the issue below.

Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/92

(I also ran `flutter format .`, which caused some formatting to be updated)

