### PR TITLE
Split location page into a separate widget, asks for location verification for checkup.

### DIFF
--- a/lib/src/data/models/preferences.dart
+++ b/lib/src/data/models/preferences.dart
@@ -1,3 +1,4 @@
+import 'package:covidnearme/src/data/models/symptom_report.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:uuid/uuid.dart';
 import 'package:uuid/uuid_util.dart';
@@ -12,12 +13,14 @@ class Preferences {
   final bool completedTutorial;
   final bool agreedToTerms;
   final Assessment lastAssessment;
+  final UserLocation location;
 
   Preferences({
     String userId,
     bool completedTutorial,
     this.agreedToTerms,
     this.lastAssessment,
+    this.location,
   })  : completedTutorial = completedTutorial ?? false,
         userId = userId ??
             Uuid().v4(
@@ -30,12 +33,14 @@ class Preferences {
     bool completedTutorial,
     bool agreedToTerms,
     Assessment lastAssessment,
+    UserLocation location,
   }) {
     return Preferences(
       userId: this.userId,
       completedTutorial: completedTutorial ?? this.completedTutorial,
       agreedToTerms: agreedToTerms ?? this.agreedToTerms,
       lastAssessment: lastAssessment ?? this.lastAssessment,
+      location: location ?? this.location,
     );
   }
 
@@ -45,5 +50,5 @@ class Preferences {
 
   @override
   String toString() =>
-      'Preferences { userId: $userId, lastAssessment: $lastAssessment }';
+      'Preferences { userId: $userId, lastAssessment: $lastAssessment, agreedToTerms: $agreedToTerms, location: $location }';
 }

--- a/lib/src/data/models/preferences.g.dart
+++ b/lib/src/data/models/preferences.g.dart
@@ -14,6 +14,9 @@ Preferences _$PreferencesFromJson(Map<String, dynamic> json) {
     lastAssessment: json['last_assessment'] == null
         ? null
         : Assessment.fromJson(json['last_assessment'] as Map<String, dynamic>),
+    location: json['location'] == null
+        ? null
+        : UserLocation.fromJson(json['location'] as Map<String, dynamic>),
   );
 }
 
@@ -23,4 +26,5 @@ Map<String, dynamic> _$PreferencesToJson(Preferences instance) =>
       'completed_tutorial': instance.completedTutorial,
       'agreed_to_terms': instance.agreedToTerms,
       'last_assessment': instance.lastAssessment?.toJson(),
+      'location': instance.location?.toJson(),
     };

--- a/lib/src/data/models/symptom_report.dart
+++ b/lib/src/data/models/symptom_report.dart
@@ -5,7 +5,7 @@ part 'symptom_report.g.dart';
 @JsonSerializable(explicitToJson: true)
 class SymptomReport {
   String userId;
-  SymptomReportLocation location;
+  UserLocation location;
   List<QuestionResponse> questionResponses;
   bool dataContributionPreference;
 
@@ -40,19 +40,19 @@ class QuestionResponse {
 }
 
 @JsonSerializable()
-class SymptomReportLocation {
+class UserLocation {
   String zipCode;
 
   /// ISO 3166-1 alpha-2.
   String country;
 
-  SymptomReportLocation({
+  UserLocation({
     this.zipCode,
     this.country,
   });
 
-  factory SymptomReportLocation.fromJson(Map<String, dynamic> json) =>
-      _$SymptomReportLocationFromJson(json);
+  factory UserLocation.fromJson(Map<String, dynamic> json) =>
+      _$UserLocationFromJson(json);
 
-  Map<String, dynamic> toJson() => _$SymptomReportLocationToJson(this);
+  Map<String, dynamic> toJson() => _$UserLocationToJson(this);
 }

--- a/lib/src/data/models/symptom_report.g.dart
+++ b/lib/src/data/models/symptom_report.g.dart
@@ -11,8 +11,7 @@ SymptomReport _$SymptomReportFromJson(Map<String, dynamic> json) {
     userId: json['user_id'] as String,
     location: json['location'] == null
         ? null
-        : SymptomReportLocation.fromJson(
-            json['location'] as Map<String, dynamic>),
+        : UserLocation.fromJson(json['location'] as Map<String, dynamic>),
     questionResponses: (json['question_responses'] as List)
         ?.map((e) => e == null
             ? null
@@ -44,16 +43,14 @@ Map<String, dynamic> _$QuestionResponseToJson(QuestionResponse instance) =>
       'response': instance.response,
     };
 
-SymptomReportLocation _$SymptomReportLocationFromJson(
-    Map<String, dynamic> json) {
-  return SymptomReportLocation(
+UserLocation _$UserLocationFromJson(Map<String, dynamic> json) {
+  return UserLocation(
     zipCode: json['zip_code'] as String,
     country: json['country'] as String,
   );
 }
 
-Map<String, dynamic> _$SymptomReportLocationToJson(
-        SymptomReportLocation instance) =>
+Map<String, dynamic> _$UserLocationToJson(UserLocation instance) =>
     <String, dynamic>{
       'zip_code': instance.zipCode,
       'country': instance.country,

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -208,12 +208,12 @@
 
   "temperatureStepTitle": "Take your temperature",
   "@temperatureStepTitle": {
-    "description": "Title that appears above the textfield where the user enters their temperature"
+    "description": "Title that appears above the text field where the user enters their temperature"
   },
 
   "temperatureStepInputLabel": "Enter your temperature",
   "@temperatureStepInputLabel": {
-    "description": "Title that appears within the textfield where the user enters their temperature"
+    "description": "Title that appears within the text field where the user enters their temperature"
   },
 
   "temperatureStepHelp": "HOW TO TAKE YOUR TEMPERATURE",
@@ -221,9 +221,14 @@
     "description": "Label for a button that brings up a help screen"
   },
 
-  "locationStepTitle": "Enter your location",
+  "tutorialLocationStepTitle": "Enter your location",
+  "@tutorialLocationStepTitle": {
+    "description": "Title that appears above the text field where the user enters their location during the tutorial"
+  },
+
+  "locationStepTitle": "Verify your location",
   "@locationStepTitle": {
-    "description": "Title that appears above the textfield where the user enters their location"
+    "description": "Title that appears above the text field where the user enters their location"
   },
 
   "locationStepInvalidZipCode": "Please enter a valid USPS ZIP code",
@@ -238,7 +243,7 @@
 
   "locationStepZipCode": "5-Digit ZIP Code",
   "@locationStepZipCode": {
-    "description": "Title that appears within the textfield where the user enters their ZIP code"
+    "description": "Title that appears within the text field where the user enters their ZIP code"
   },
 
   "locationStepCountryHelper": "If you are not in the US, what is your country?",
@@ -258,7 +263,7 @@
 
   "locationStepCountry": "Country",
   "@locationStepCountry": {
-    "description": "Title that appears within the textfield where the user enters their country"
+    "description": "Title that appears within the text field where the user enters their country"
   },
 
   "homeScreenHeading": "Concerned about your health?",

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -215,16 +215,19 @@ abstract class AppLocalizations {
   // Return to the checkup screen from the dialog that explains how to take your temperature in 5 steps
   String get temperatureStepHowToDialogReturn;
 
-  // Title that appears above the textfield where the user enters their temperature
+  // Title that appears above the text field where the user enters their temperature
   String get temperatureStepTitle;
 
-  // Title that appears within the textfield where the user enters their temperature
+  // Title that appears within the text field where the user enters their temperature
   String get temperatureStepInputLabel;
 
   // Label for a button that brings up a help screen
   String get temperatureStepHelp;
 
-  // Title that appears above the textfield where the user enters their location
+  // Title that appears above the text field where the user enters their location during the tutorial
+  String get tutorialLocationStepTitle;
+
+  // Title that appears above the text field where the user enters their location
   String get locationStepTitle;
 
   // Error that appears when the user enters their zip code incorrectly.
@@ -233,7 +236,7 @@ abstract class AppLocalizations {
   // Error that appears when the user enters their country incorrectly.
   String get locationStepInvalidCountry;
 
-  // Title that appears within the textfield where the user enters their ZIP code
+  // Title that appears within the text field where the user enters their ZIP code
   String get locationStepZipCode;
 
   // Helper text describing what to enter in the text field for country.
@@ -245,7 +248,7 @@ abstract class AppLocalizations {
   // Radio button selection indicating that the user lives outside of the USA.
   String get locationStepAnotherCountry;
 
-  // Title that appears within the textfield where the user enters their country
+  // Title that appears within the text field where the user enters their country
   String get locationStepCountry;
 
   // Heading text for the home screen

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -184,7 +184,10 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get temperatureStepHelp => 'HOW TO TAKE YOUR TEMPERATURE';
 
   @override
-  String get locationStepTitle => 'Enter your location';
+  String get tutorialLocationStepTitle => 'Enter your location';
+
+  @override
+  String get locationStepTitle => 'Verify your location';
 
   @override
   String get locationStepInvalidZipCode => 'Please enter a valid USPS ZIP code';

--- a/lib/src/ui/screens/symptom_report/steps/location.dart
+++ b/lib/src/ui/screens/symptom_report/steps/location.dart
@@ -1,15 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'package:covidnearme/src/blocs/preferences/preferences.dart';
 import 'package:covidnearme/src/blocs/symptom_report/symptom_report.dart';
 import 'package:covidnearme/src/data/models/symptom_report.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:covidnearme/src/ui/utils/symptom_reports.dart';
-import 'package:covidnearme/src/ui/widgets/questions/inputs/country_dropdown.dart';
 import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
 import 'package:covidnearme/src/ui/widgets/questions/step_finished_button.dart';
-import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 
 import 'index.dart';
 
@@ -21,169 +19,70 @@ class LocationStep extends StatefulWidget implements SymptomReportStep {
 }
 
 class _LocationStepState extends State<LocationStep> {
-  bool _countryIsValid = false;
-  bool _zipIsValid = false;
-  bool get _isUSA => _displayedCountry == "US";
-  // Keep the values entered, so that when switching between modes,
-  // they stick, but we don't have to update the preferences values.
-  String _displayedZip;
-  String _displayedCountry = 'US';
-
-  LocalKey zipCodeKey = ValueKey<String>('ZIP Code');
-  LocalKey countryKey = ValueKey<String>('Country');
-
-  String _validateZipCode(String value, [AppLocalizations localizations]) {
-    if (value != '') {
-      final int zipValue = int.tryParse(value, radix: 10);
-      if (value.length != 5 || zipValue == null) {
-        return localizations?.locationStepInvalidZipCode ?? '';
-      }
-    }
-    return null;
-  }
-
-  bool _updateValidity() {
-    bool valid = false;
-    if (_isUSA) {
-      valid = _displayedZip != null &&
-          _displayedZip.isNotEmpty &&
-          _validateZipCode(_displayedZip) == null;
-      if (_zipIsValid != valid) {
-        setState(() {
-          _zipIsValid = valid;
-        });
-      }
-    } else {
-      valid = _displayedCountry != 'None';
-      if (_countryIsValid != valid) {
-        setState(() {
-          _countryIsValid = valid;
-        });
-      }
-    }
-    return valid;
-  }
-
-  void _updateZipCode({
-    String zipCode,
-    @required SymptomReportStateInProgress symptomReportState,
-    @required AppLocalizations localizations,
+  void _updateData({
+    UserLocation location,
+    @required SymptomReportState symptomReportState,
+    @required PreferencesState preferencesState,
   }) {
-    assert(zipCode != null);
-    setState(() {
-      _displayedZip = zipCode;
-    });
-    // Validate before saving.
-    if (!_updateValidity()) {
-      return;
+    if (location.zipCode != null) {
+      location.country = 'US';
     }
-
-    updateSymptomReport(
-      symptomReportState: symptomReportState,
-      context: context,
-      updateFunction: (SymptomReport symptomReport) {
-        final SymptomReportLocation newResponse = SymptomReportLocation(
-          zipCode: zipCode,
-          country: 'US',
-        );
-
-        symptomReport.location = newResponse;
-        return symptomReport;
-      },
-    );
-  }
-
-  void _updateCountry({
-    String countryCode,
-    @required SymptomReportStateInProgress symptomReportState,
-    @required AppLocalizations localizations,
-  }) {
-    assert(countryCode != null);
+    assert(location.country != null);
+    assert(symptomReportState != null);
     setState(() {
-      _displayedCountry = countryCode;
+      // Save response to preferences to update default.
+      Preferences newPreferences = preferencesState.preferences.cloneWith(
+        location: location,
+      );
+      context.bloc<PreferencesBloc>().add(UpdatePreferences(newPreferences));
+
+      updateSymptomReport(
+        symptomReportState: symptomReportState,
+        context: context,
+        updateFunction: (SymptomReport symptomReport) {
+          symptomReport.location = location;
+          return symptomReport;
+        },
+      );
     });
-    // Validate before saving.
-    if (!_updateValidity()) {
-      return;
-    }
-
-    updateSymptomReport(
-      symptomReportState: symptomReportState,
-      context: context,
-      updateFunction: (SymptomReport symptomReport) {
-        final SymptomReportLocation newResponse = SymptomReportLocation(
-          zipCode: null,
-          country: countryCode,
-        );
-
-        symptomReport.location = newResponse;
-        return symptomReport;
-      },
-    );
   }
 
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
-    return BlocBuilder<SymptomReportBloc, SymptomReportState>(
-      builder: (context, state) {
-        final SymptomReportStateInProgress symptomReportState = state;
-        final SymptomReportLocation existingResponse =
-            symptomReportState.symptomReport.location;
-        _displayedZip ??=
-            existingResponse != null ? existingResponse.zipCode : '';
-        _displayedCountry ??=
-            existingResponse != null ? existingResponse.country : '';
-        return ScrollableBody(
-          child: Container(
-            color: Theme.of(context).backgroundColor,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 40),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Center(
-                    child: Padding(
-                      padding: EdgeInsets.only(bottom: 20),
-                      child: Text(
-                        localizations.locationStepTitle,
-                        style: Theme.of(context).textTheme.title.copyWith(
-                              fontSize: 26,
-                            ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                  CountryDropdown(
-                    onChanged: (String value) => _updateCountry(
-                      countryCode: value,
-                      symptomReportState: symptomReportState,
-                      localizations: localizations,
-                    ),
-                    value: _displayedCountry,
-                  ),
-                  if (_isUSA)
-                    EntryField(
-                      key: zipCodeKey,
-                      initialValue: _displayedZip,
-                      onChanged: (String value) => _updateZipCode(
-                        zipCode: value,
-                        symptomReportState: symptomReportState,
-                        localizations: localizations,
-                      ),
-                      label: localizations.locationStepZipCode,
-                      keyboardType: TextInputType.numberWithOptions(
-                          decimal: false, signed: false),
-                      validator: (String string) =>
-                          _validateZipCode(string, localizations),
-                    ),
-                  StepFinishedButton(validated: true),
-                ],
-              ),
+    return BlocBuilder<PreferencesBloc, PreferencesState>(
+      builder: (BuildContext context, PreferencesState preferencesState) {
+        return BlocBuilder<SymptomReportBloc, SymptomReportState>(
+            builder: (BuildContext context, SymptomReportState state) {
+          final SymptomReportStateInProgress symptomReportState = state;
+          final UserLocation currentLocation =
+              symptomReportState?.symptomReport?.location ?? preferencesState.preferences.location;
+          return LocationEntry(
+            updateData: (UserLocation location) => _updateData(
+              location: location,
+              symptomReportState: symptomReportState,
+              preferencesState: preferencesState,
             ),
-          ),
-        );
+            title: localizations.locationStepTitle,
+            location: currentLocation,
+            finish: StepFinishedButton(
+              validated: true,
+              isLastStep: widget.isLastStep,
+              onPressed: () {
+                // Save the data to the symptom report if the user didn't cause
+                // any changes to the screen.
+                if (currentLocation != null &&
+                    symptomReportState?.symptomReport?.location == null) {
+                  _updateData(
+                    location: currentLocation,
+                    symptomReportState: symptomReportState,
+                    preferencesState: preferencesState,
+                  );
+                }
+              },
+            ),
+          );
+        });
       },
     );
   }

--- a/lib/src/ui/screens/tutorial/steps/consent.dart
+++ b/lib/src/ui/screens/tutorial/steps/consent.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -18,7 +16,10 @@ class ConsentStep extends StatelessWidget {
     );
     context.bloc<PreferencesBloc>().add(UpdatePreferences(newPreferences));
 
-    if (response) {
+    if (response && newPreferences.location != null) {
+      // If the user consented, but they have already specified their location,
+      // skip the location step.
+
       // Navigate to home page and put it at the
       // bottom of the navigation stack if consent is given.
       Navigator.pushNamedAndRemoveUntil(
@@ -27,7 +28,7 @@ class ConsentStep extends StatelessWidget {
         (Route<dynamic> route) => false,
       );
     } else {
-      // Advance to the denied consent page if consent is not given.
+      // Advance to the ConsentBranch step.
       Provider.of<PageController>(context, listen: false).nextPage(
         duration: Duration(milliseconds: 400),
         curve: Curves.easeInOut,

--- a/lib/src/ui/screens/tutorial/steps/consent_branch.dart
+++ b/lib/src/ui/screens/tutorial/steps/consent_branch.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:covidnearme/src/blocs/preferences/preferences.dart';
+import 'package:covidnearme/src/ui/screens/tutorial/steps/denied_consent.dart';
+import 'package:covidnearme/src/ui/screens/tutorial/steps/location.dart';
+
+class ConsentBranchStep extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PreferencesBloc, PreferencesState>(
+      builder: (context, state) {
+        final bool agreed = state.preferences.agreedToTerms != null &&
+            state.preferences.agreedToTerms;
+        if (agreed) {
+          return TutorialLocationStep();
+        } else {
+          return DeniedConsent();
+        }
+      },
+    );
+  }
+}

--- a/lib/src/ui/screens/tutorial/steps/location.dart
+++ b/lib/src/ui/screens/tutorial/steps/location.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'package:covidnearme/src/blocs/preferences/preferences.dart';
+import 'package:covidnearme/src/data/models/symptom_report.dart';
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:covidnearme/src/ui/router.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
+
+class TutorialLocationStep extends StatefulWidget {
+  bool get isLastStep => false;
+
+  @override
+  _TutorialLocationStepState createState() => _TutorialLocationStepState();
+}
+
+class _TutorialLocationStepState extends State<TutorialLocationStep> {
+  void _updateData({
+    UserLocation location,
+    @required PreferencesState preferencesState,
+  }) {
+    if (location.zipCode != null) {
+      location.country = 'US';
+    }
+    assert(location.country != null);
+    setState(() {
+      // Save response to preferences to update default.
+      Preferences newPreferences = preferencesState.preferences.cloneWith(
+        location: location,
+      );
+      context.bloc<PreferencesBloc>().add(UpdatePreferences(newPreferences));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+    return BlocBuilder<PreferencesBloc, PreferencesState>(
+        builder: (BuildContext context, PreferencesState preferencesState) {
+      return LocationEntry(
+        updateData: (UserLocation location) => _updateData(
+          location: location,
+          preferencesState: preferencesState,
+        ),
+        title: localizations.tutorialLocationStepTitle,
+        location: preferencesState.preferences.location,
+        finish: Container(
+          padding: EdgeInsets.symmetric(horizontal: 20),
+          width: 400,
+          child: RaisedButton(
+            onPressed: () {
+              // Navigate to home page and put it at the
+              // bottom of the navigation stack if consent is given.
+              Navigator.pushNamedAndRemoveUntil(
+                context,
+                HomeScreen.routeName,
+                (Route<dynamic> route) => false,
+              );
+            },
+            child: Text(localizations.checkupStepFinishedSubmit),
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/src/ui/screens/tutorial/tutorial.dart
+++ b/lib/src/ui/screens/tutorial/tutorial.dart
@@ -3,7 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
+import 'package:covidnearme/src/ui/screens/tutorial/steps/consent_branch.dart';
 import 'package:covidnearme/src/ui/widgets/network_unavailable_banner.dart';
+
 import 'steps/index.dart';
 
 class TutorialScreen extends StatefulWidget {
@@ -44,8 +46,7 @@ class _TutorialScreenState extends State<TutorialScreen> {
                   children: <Widget>[
                     IntroStep(),
                     ConsentStep(),
-                    if (state.preferences.agreedToTerms == false)
-                      DeniedConsent(),
+                    ConsentBranchStep(),
                   ],
                 ),
               ),

--- a/lib/src/ui/widgets/questions/inputs/index.dart
+++ b/lib/src/ui/widgets/questions/inputs/index.dart
@@ -2,3 +2,4 @@ export 'entry_field.dart';
 export 'labeled_radio.dart';
 export 'radio_button_scale.dart';
 export 'temperature_field.dart';
+export 'location_entry.dart';

--- a/lib/src/ui/widgets/questions/inputs/location_entry.dart
+++ b/lib/src/ui/widgets/questions/inputs/location_entry.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:covidnearme/src/data/models/symptom_report.dart';
+import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/country_dropdown.dart';
+import 'package:covidnearme/src/ui/widgets/questions/inputs/index.dart';
+import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
+
+import 'index.dart';
+
+class LocationEntry extends StatefulWidget {
+  const LocationEntry({
+    Key key,
+    @required this.updateData,
+    @required this.location,
+    this.finish,
+    this.title,
+  })  : assert(updateData != null),
+        super(key: key);
+
+  final ValueChanged<UserLocation> updateData;
+  final UserLocation location;
+  final String title;
+  final Widget finish;
+
+  @override
+  _LocationEntryState createState() => _LocationEntryState();
+}
+
+class _LocationEntryState extends State<LocationEntry> {
+  bool _countryIsValid = false;
+  bool _zipIsValid = false;
+  bool get _isUSA => _displayedLocation.country == "US";
+  // Keep the values entered, so that when switching between modes,
+  // they stick, but we don't have to update the preferences values.
+  UserLocation _displayedLocation = UserLocation(country: 'US', zipCode: null);
+
+  LocalKey zipCodeKey = ValueKey<String>('ZIP Code');
+  LocalKey countryKey = ValueKey<String>('Country');
+
+  String _validateZipCode(String value, [AppLocalizations localizations]) {
+    if (value != '') {
+      final int zipValue = int.tryParse(value, radix: 10);
+      if (value.length != 5 || zipValue == null) {
+        return localizations?.locationStepInvalidZipCode ?? '';
+      }
+    }
+    return null;
+  }
+
+  bool _updateValidity() {
+    bool valid = false;
+    if (_isUSA) {
+      valid = _displayedLocation.zipCode != null &&
+          _displayedLocation.zipCode.isNotEmpty &&
+          _validateZipCode(_displayedLocation.zipCode) == null;
+      if (_zipIsValid != valid) {
+        setState(() {
+          _zipIsValid = valid;
+        });
+      }
+    } else {
+      valid = _displayedLocation.country != 'None';
+      if (_countryIsValid != valid) {
+        setState(() {
+          _countryIsValid = valid;
+        });
+      }
+    }
+    return valid;
+  }
+
+  void _updateLocation(UserLocation location) {
+    if (location.zipCode != null) {
+      location.country = 'US';
+    }
+    assert(location.country != null);
+    setState(() {
+      _displayedLocation = location;
+    });
+
+    // Validate before saving.
+    if (!_updateValidity()) {
+      return;
+    }
+
+    widget.updateData(location);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AppLocalizations localizations = AppLocalizations.of(context);
+    _displayedLocation.zipCode ??= widget.location?.zipCode ?? '';
+    _displayedLocation.country ??= widget.location?.country ?? '';
+
+    return ScrollableBody(
+      child: Container(
+        color: Theme.of(context).backgroundColor,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 40),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              if (widget.title != null)
+                Center(
+                  child: Padding(
+                    padding: EdgeInsets.only(bottom: 20),
+                    child: Text(
+                      widget.title,
+                      style: Theme.of(context).textTheme.title.copyWith(
+                            fontSize: 26,
+                          ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              CountryDropdown(
+                onChanged: (String value) => _updateLocation(
+                    UserLocation(country: value, zipCode: null)),
+                value: _displayedLocation.country,
+              ),
+              if (_isUSA)
+                EntryField(
+                  key: zipCodeKey,
+                  initialValue: _displayedLocation.zipCode,
+                  onChanged: (String value) => _updateLocation(
+                      UserLocation(zipCode: value, country: 'US')),
+                  label: localizations.locationStepZipCode,
+                  keyboardType: TextInputType.numberWithOptions(
+                      decimal: false, signed: false),
+                  validator: (String string) =>
+                      _validateZipCode(string, localizations),
+                ),
+              if (widget.finish != null) widget.finish,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/questions/step_finished_button.dart
+++ b/lib/src/ui/widgets/questions/step_finished_button.dart
@@ -10,10 +10,12 @@ class StepFinishedButton extends StatelessWidget {
     Key key,
     @required this.validated,
     this.isLastStep = false,
+    this.onPressed,
   }) : super(key: key);
 
   final bool isLastStep;
   final bool validated;
+  final VoidCallback onPressed;
 
   Widget _getCompletionMessage(AppLocalizations localizations) {
     return ConstrainedBox(
@@ -30,6 +32,18 @@ class StepFinishedButton extends StatelessWidget {
     );
   }
 
+  void _handleOnPressed(BuildContext context) {
+    onPressed?.call();
+    if (isLastStep) {
+      context.bloc<SymptomReportBloc>().add(CompleteSymptomReport());
+    } else {
+      Provider.of<PageController>(context, listen: false).nextPage(
+        duration: Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final AppLocalizations localizations = AppLocalizations.of(context);
@@ -40,21 +54,7 @@ class StepFinishedButton extends StatelessWidget {
           alignment: isLastStep ? null : AlignmentDirectional.centerEnd,
           width: 400,
           child: RaisedButton(
-            onPressed: validated
-                ? () {
-                    if (isLastStep) {
-                      context
-                          .bloc<SymptomReportBloc>()
-                          .add(CompleteSymptomReport());
-                    } else {
-                      Provider.of<PageController>(context, listen: false)
-                          .nextPage(
-                        duration: Duration(milliseconds: 400),
-                        curve: Curves.easeInOut,
-                      );
-                    }
-                  }
-                : null,
+            onPressed: validated ? () => _handleOnPressed(context) : null,
             child: Text(isLastStep
                 ? localizations.checkupStepFinishedSubmit
                 : localizations.checkupStepFinishedNext),

--- a/test/ui/screens/checkup_test.dart
+++ b/test/ui/screens/checkup_test.dart
@@ -78,7 +78,8 @@ Widget setUpCheckupScreen({
   );
   preferences ??= PreferencesBloc();
   return MaterialApp(
-    localizationsDelegates: AppLocalizations.localizationsDelegates.followedBy([CountryLocalizations.delegate]),
+    localizationsDelegates: AppLocalizations.localizationsDelegates
+        .followedBy([CountryLocalizations.delegate]),
     supportedLocales: AppLocalizations.supportedLocales,
     home: Scaffold(
       body: BlocProvider(

--- a/test_driver/smoke_workflow_test.dart
+++ b/test_driver/smoke_workflow_test.dart
@@ -36,6 +36,9 @@ void main() {
 
     // Now agree.
     await driver.tap(find.text('I AGREE'));
+
+    // Now submit an empty default location.
+    await driver.tap(find.text('SUBMIT'));
   });
 
   test('User can go back from the checkup screen to home', () async {


### PR DESCRIPTION
This splits the location page into a separate widget that can be used in multiple places, and adds a step after a successful consent page that asks the user for their location. That location is stored in preferences, and the preferences location is used for a default for the "verify location" page that is the first page of the checkup.

Also updated the driver tests to match.

Fixes #156