### PR TITLE
Removed unused app_en.arb messages

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -56,11 +56,6 @@
     "description": "An error occurred while trying to fetch data"
   },
 
-  "checkupScreenHUDLabel": "Loading your assessment",
-  "@checkupScreenHUDLabel": {
-    "description": "A label that indicates that the app is busy loading the patient's assessment"
-  },
-
   "checkupScreenTitle": "Your Health Checkup",
   "@checkupScreenTitle": {
     "description": "Title for the checkup screen"
@@ -151,16 +146,6 @@
     "description": "Subsection heading for recommendations about how to measure the user's temperature"
   },
 
-  "temperatureStepPleaseEnterValueBelow": "Please enter a value below 150 ℉",
-  "@temperatureStepPleaseEnterValueBelow": {
-    "description": "Ask the user to correct their temperature reading"
-  },
-
-  "temperatureStepPleaseEnterValueAbove": "Please enter a value above 70 ℉",
-  "@temperatureStepPleaseEnterValueAbove": {
-    "description": "Ask the user to correct their temperature reading"
-  },
-
   "temperatureStepHowToDialogTitle": "Taking your Temperature",
   "@temperatureStepHowToDialogTitle": {
     "description": "Title for a dialog that explains how to take your temperature in 5 steps"
@@ -211,11 +196,6 @@
     "description": "Title that appears above the text field where the user enters their temperature"
   },
 
-  "temperatureStepInputLabel": "Enter your temperature",
-  "@temperatureStepInputLabel": {
-    "description": "Title that appears within the text field where the user enters their temperature"
-  },
-
   "temperatureStepHelp": "HOW TO TAKE YOUR TEMPERATURE",
   "@temperatureStepHelp": {
     "description": "Label for a button that brings up a help screen"
@@ -236,34 +216,9 @@
     "description": "Error that appears when the user enters their zip code incorrectly."
   },
 
-  "locationStepInvalidCountry": "Please just enter the name of your country",
-  "@locationStepInvalidCountry": {
-    "description": "Error that appears when the user enters their country incorrectly."
-  },
-
   "locationStepZipCode": "5-Digit ZIP Code",
   "@locationStepZipCode": {
     "description": "Title that appears within the text field where the user enters their ZIP code"
-  },
-
-  "locationStepCountryHelper": "If you are not in the US, what is your country?",
-  "@locationStepCountryHelper": {
-    "description": "Helper text describing what to enter in the text field for country."
-  },
-
-  "locationStepInUSA": "In the United States",
-  "@locationStepInUSA": {
-    "description": "Radio button selection indicating that the user lives in the USA."
-  },
-
-  "locationStepAnotherCountry": "In another country",
-  "@locationStepAnotherCountry": {
-    "description": "Radio button selection indicating that the user lives outside of the USA."
-  },
-
-  "locationStepCountry": "Country",
-  "@locationStepCountry": {
-    "description": "Title that appears within the text field where the user enters their country"
   },
 
   "homeScreenHeading": "Concerned about your health?",
@@ -411,24 +366,19 @@
     "description": "Label for the button that indicates that the user will accept the app license"
   },
 
-  "consentStepLoading": "Loading...",
-  "@consentStepLoading": {
-    "description": "Displayed while the app is loading the next screen"
+  "networkUnavailableBannerContinueOffline": "CONTINUE OFFLINE",
+  "@networkUnavailableBannerContinueOffline": {
+     "description": "Label for button that indicates that the user will continue using the app offline"
   },
 
-  "networkUnavailableBannerContinueOffline":"CONTINUE OFFLINE",
-  "@networkUnavailableBannerContinueOffline":{
-     "description":"Label for button that indicates that the user will continue using the app offline"
+  "networkUnavailableBannerConnectToWiFi": "CONNECT TO WIFI",
+  "@networkUnavailableBannerConnectToWiFi": {
+     "description": "Label for button that opens the system network settings"
   },
 
-  "networkUnavailableBannerConnectToWiFi":"CONNECT TO WIFI",
-  "@networkUnavailableBannerConnectToWiFi":{
-     "description":"Label for button that opens the system network settings"
-  },
-
-  "networkUnavailableBannerMessage":"You seem to be offline. Please check your network settings and try again.",
-  "@networkUnavailableBannerMessage":{
-     "description":"Message shown on the banner displayed when no network connection is detected"
+  "networkUnavailableBannerMessage": "You seem to be offline. Please check your network settings and try again.",
+  "@networkUnavailableBannerMessage": {
+     "description": "Message shown on the banner displayed when no network connection is detected"
   },
 
   "deniedConsentBackButton": "Go back to the informed consent screen",
@@ -439,11 +389,6 @@
   "questionShortnessOfBreathTitle": "Are you experiencing shortness of breath?",
   "@questionShortnessOfBreathTitle": {
     "description": "Question title."
-  },
-
-  "questionShortnessOfBreathSubtitle": "Do you feel like you can't get enough air?",
-  "@questionShortnessOfBreathSubtitle": {
-    "description": "Question subtitle."
   },
 
   "questionShortnessOfBreathAnswer0": "None",
@@ -628,16 +573,6 @@
   "questionNo": "No",
   "@questionNo": {
     "description": "Question answer."
-  },
-
-  "questionHaveYouBeenFluTestedSemantics0": "Yes, I have been tested for flu, pneumonia, or other respiratory illness.",
-  "@questionHaveYouBeenFluTestedSemantics0": {
-    "description": "Question accessibility semantics description."
-  },
-
-  "questionHaveYouBeenFluTestedSemantics1": "No, I have not been tested for flu, pneumonia, or other respiratory illness.",
-  "@questionHaveYouBeenFluTestedSemantics1": {
-    "description": "Question accessibility semantics description."
   },
 
   "questionFluTestPositiveTitle": "Was the test positive?",

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -131,9 +131,6 @@ abstract class AppLocalizations {
   // An error occurred while trying to fetch data
   String get checkupScreenErrorRetrievingExperience;
 
-  // A label that indicates that the app is busy loading the patient's assessment
-  String get checkupScreenHUDLabel;
-
   // Title for the checkup screen
   String get checkupScreenTitle;
 
@@ -182,12 +179,6 @@ abstract class AppLocalizations {
   // Subsection heading for recommendations about how to measure the user's temperature
   String get temperatureStepHowHeading;
 
-  // Ask the user to correct their temperature reading
-  String get temperatureStepPleaseEnterValueBelow;
-
-  // Ask the user to correct their temperature reading
-  String get temperatureStepPleaseEnterValueAbove;
-
   // Title for a dialog that explains how to take your temperature in 5 steps
   String get temperatureStepHowToDialogTitle;
 
@@ -218,9 +209,6 @@ abstract class AppLocalizations {
   // Title that appears above the text field where the user enters their temperature
   String get temperatureStepTitle;
 
-  // Title that appears within the text field where the user enters their temperature
-  String get temperatureStepInputLabel;
-
   // Label for a button that brings up a help screen
   String get temperatureStepHelp;
 
@@ -233,23 +221,8 @@ abstract class AppLocalizations {
   // Error that appears when the user enters their zip code incorrectly.
   String get locationStepInvalidZipCode;
 
-  // Error that appears when the user enters their country incorrectly.
-  String get locationStepInvalidCountry;
-
   // Title that appears within the text field where the user enters their ZIP code
   String get locationStepZipCode;
-
-  // Helper text describing what to enter in the text field for country.
-  String get locationStepCountryHelper;
-
-  // Radio button selection indicating that the user lives in the USA.
-  String get locationStepInUSA;
-
-  // Radio button selection indicating that the user lives outside of the USA.
-  String get locationStepAnotherCountry;
-
-  // Title that appears within the text field where the user enters their country
-  String get locationStepCountry;
 
   // Heading text for the home screen
   String get homeScreenHeading;
@@ -335,9 +308,6 @@ abstract class AppLocalizations {
   // Label for the button that indicates that the user will accept the app license
   String get consentStepIAgree;
 
-  // Displayed while the app is loading the next screen
-  String get consentStepLoading;
-
   // Label for button that indicates that the user will continue using the app offline
   String get networkUnavailableBannerContinueOffline;
 
@@ -352,9 +322,6 @@ abstract class AppLocalizations {
 
   // Question title.
   String get questionShortnessOfBreathTitle;
-
-  // Question subtitle.
-  String get questionShortnessOfBreathSubtitle;
 
   // Question answer.
   String get questionShortnessOfBreathAnswer0;
@@ -466,12 +433,6 @@ abstract class AppLocalizations {
 
   // Question answer.
   String get questionNo;
-
-  // Question accessibility semantics description.
-  String get questionHaveYouBeenFluTestedSemantics0;
-
-  // Question accessibility semantics description.
-  String get questionHaveYouBeenFluTestedSemantics1;
 
   // Question title.
   String get questionFluTestPositiveTitle;

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -62,9 +62,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
       'There was an error retrieving the checkup experience. Please try again later.';
 
   @override
-  String get checkupScreenHUDLabel => 'Loading your assessment';
-
-  @override
   String get checkupScreenTitle => 'Your Health Checkup';
 
   @override
@@ -134,14 +131,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get temperatureStepHowHeading => 'How?';
 
   @override
-  String get temperatureStepPleaseEnterValueBelow =>
-      'Please enter a value below 150 ℉';
-
-  @override
-  String get temperatureStepPleaseEnterValueAbove =>
-      'Please enter a value above 70 ℉';
-
-  @override
   String get temperatureStepHowToDialogTitle => 'Taking your Temperature';
 
   @override
@@ -178,9 +167,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get temperatureStepTitle => 'Take your temperature';
 
   @override
-  String get temperatureStepInputLabel => 'Enter your temperature';
-
-  @override
   String get temperatureStepHelp => 'HOW TO TAKE YOUR TEMPERATURE';
 
   @override
@@ -193,24 +179,7 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get locationStepInvalidZipCode => 'Please enter a valid USPS ZIP code';
 
   @override
-  String get locationStepInvalidCountry =>
-      'Please just enter the name of your country';
-
-  @override
   String get locationStepZipCode => '5-Digit ZIP Code';
-
-  @override
-  String get locationStepCountryHelper =>
-      'If you are not in the US, what is your country?';
-
-  @override
-  String get locationStepInUSA => 'In the United States';
-
-  @override
-  String get locationStepAnotherCountry => 'In another country';
-
-  @override
-  String get locationStepCountry => 'Country';
 
   @override
   String get homeScreenHeading => 'Concerned about your health?';
@@ -308,9 +277,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   String get consentStepIAgree => 'I AGREE';
 
   @override
-  String get consentStepLoading => 'Loading...';
-
-  @override
   String get networkUnavailableBannerContinueOffline => 'CONTINUE OFFLINE';
 
   @override
@@ -327,10 +293,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
   @override
   String get questionShortnessOfBreathTitle =>
       'Are you experiencing shortness of breath?';
-
-  @override
-  String get questionShortnessOfBreathSubtitle =>
-      'Do you feel like you can\'t get enough air?';
 
   @override
   String get questionShortnessOfBreathAnswer0 => 'None';
@@ -448,14 +410,6 @@ If this is all OK and you are 18 years old or older, please click \"I agree\". O
 
   @override
   String get questionNo => 'No';
-
-  @override
-  String get questionHaveYouBeenFluTestedSemantics0 =>
-      'Yes, I have been tested for flu, pneumonia, or other respiratory illness.';
-
-  @override
-  String get questionHaveYouBeenFluTestedSemantics1 =>
-      'No, I have not been tested for flu, pneumonia, or other respiratory illness.';
 
   @override
   String get questionFluTestPositiveTitle => 'Was the test positive?';


### PR DESCRIPTION
Removed the following messages from app_en.arb because they were no longer being used by the app: 
```
checkupScreenHUDLabel
temperatureStepPleaseEnterValueBelow
temperatureStepPleaseEnterValueAbove
temperatureStepInputLabel
locationStepInvalidCountry
locationStepCountryHelper
locationStepInUSA
locationStepAnotherCountry
locationStepCountry
consentStepLoading
questionShortnessOfBreathSubtitle
questionHaveYouBeenFluTestedSemantics0
questionHaveYouBeenFluTestedSemantics1
```