### PR TITLE
Add an about dialog showing licenses.

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -16,6 +16,22 @@
     "description": "Semantic Label for the about button in the home page menu."
   },
 
+  "aboutBoxDescription": "This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.\n\n",
+  "@aboutBoxDescription":  {
+    "description": "Description in the 'About' box, above a hyperlink to the source website."
+  },
+
+  "aboutBoxLinkText": "Coronavirus Diary on GitHub",
+    "@aboutBoxLinkText":  {
+      "description": "Text label on a hyperlink to the source code for the app."
+    },
+
+
+  "aboutBoxCopyright": "Copyright © 2020 Josh Smith",
+  "@aboutBoxCopyright":  {
+    "description": "Copyright notice in the 'About' box."
+  },
+
   "consentStepQuestion": "# Informed Consent\n\nSince the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.\n\nYou are anonymous. We don’t want to know who you are! We will ask for your zip code to count cases around specific hospitals. Your symptom severity will be used to guess how likely it is that you have COVID-19, and to see how many people in your region are becoming severely sick.\n\nTotal daily cases for zip codes will be provided to state and local health authorities, the CDC, and the US Government to help predict which communities need the most support. We will also make a map here on this app. Data will also be analyzed for geographic trends. For example, we might see fewer cases in areas that closed schools for a long time, or perhaps we will see that the epidemic slows down in hot weather.\n\nYou can come back later and enter new information on a different day. We will know it’s you and won’t count you twice. Maybe you feel a lot worse, or you got a COVID-19 test result and would like to let us know.\n\nWe will not sell this data. It will only be used for public health and research and deleted after the epidemic has run its course.\n\nIf this is all OK and you are 18 years old or older, please click \"I agree\". Otherwise, click \"No\".",
   "@consentStepQuestion": {
     "description": "The long informed consent question asked of users"

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -26,12 +26,6 @@
       "description": "Text label on a hyperlink to the source code for the app."
     },
 
-
-  "aboutBoxCopyright": "Copyright © 2020 Josh Smith",
-  "@aboutBoxCopyright":  {
-    "description": "Copyright notice in the 'About' box."
-  },
-
   "consentStepQuestion": "# Informed Consent\n\nSince the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.\n\nYou are anonymous. We don’t want to know who you are! We will ask for your zip code to count cases around specific hospitals. Your symptom severity will be used to guess how likely it is that you have COVID-19, and to see how many people in your region are becoming severely sick.\n\nTotal daily cases for zip codes will be provided to state and local health authorities, the CDC, and the US Government to help predict which communities need the most support. We will also make a map here on this app. Data will also be analyzed for geographic trends. For example, we might see fewer cases in areas that closed schools for a long time, or perhaps we will see that the epidemic slows down in hot weather.\n\nYou can come back later and enter new information on a different day. We will know it’s you and won’t count you twice. Maybe you feel a lot worse, or you got a COVID-19 test result and would like to let us know.\n\nWe will not sell this data. It will only be used for public health and research and deleted after the epidemic has run its course.\n\nIf this is all OK and you are 18 years old or older, please click \"I agree\". Otherwise, click \"No\".",
   "@consentStepQuestion": {
     "description": "The long informed consent question asked of users"

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -1,6 +1,21 @@
 {
   "@@locale": "en",
 
+  "homeMenuTooltip": "More",
+  "@homeMenuTooltip":  {
+    "description": "Tooltip for the 'three dots' main menu on the home page."
+  },
+
+  "homeMenuAbout": "About CovidNearMe",
+  "@homeMenuAbout":  {
+    "description": "Label for the about button in the home page menu."
+  },
+
+  "homeMenuAboutSemantics": "About Covid Near Me",
+  "@homeMenuAboutSemantics":  {
+    "description": "Semantic Label for the about button in the home page menu."
+  },
+
   "consentStepQuestion": "# Informed Consent\n\nSince the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.\n\nYou are anonymous. We don’t want to know who you are! We will ask for your zip code to count cases around specific hospitals. Your symptom severity will be used to guess how likely it is that you have COVID-19, and to see how many people in your region are becoming severely sick.\n\nTotal daily cases for zip codes will be provided to state and local health authorities, the CDC, and the US Government to help predict which communities need the most support. We will also make a map here on this app. Data will also be analyzed for geographic trends. For example, we might see fewer cases in areas that closed schools for a long time, or perhaps we will see that the epidemic slows down in hot weather.\n\nYou can come back later and enter new information on a different day. We will know it’s you and won’t count you twice. Maybe you feel a lot worse, or you got a COVID-19 test result and would like to let us know.\n\nWe will not sell this data. It will only be used for public health and research and deleted after the epidemic has run its course.\n\nIf this is all OK and you are 18 years old or older, please click \"I agree\". Otherwise, click \"No\".",
   "@consentStepQuestion": {
     "description": "The long informed consent question asked of users"

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -107,6 +107,15 @@ abstract class AppLocalizations {
   // Semantic Label for the about button in the home page menu.
   String get homeMenuAboutSemantics;
 
+  // Description in the 'About' box, above a hyperlink to the source website.
+  String get aboutBoxDescription;
+
+  // Text label on a hyperlink to the source code for the app.
+  String get aboutBoxLinkText;
+
+  // Copyright notice in the 'About' box.
+  String get aboutBoxCopyright;
+
   // The long informed consent question asked of users
   String get consentStepQuestion;
 

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -113,9 +113,6 @@ abstract class AppLocalizations {
   // Text label on a hyperlink to the source code for the app.
   String get aboutBoxLinkText;
 
-  // Copyright notice in the 'About' box.
-  String get aboutBoxCopyright;
-
   // The long informed consent question asked of users
   String get consentStepQuestion;
 

--- a/lib/src/l10n/app_localizations.dart
+++ b/lib/src/l10n/app_localizations.dart
@@ -98,6 +98,15 @@ abstract class AppLocalizations {
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
+  // Tooltip for the 'three dots' main menu on the home page.
+  String get homeMenuTooltip;
+
+  // Label for the about button in the home page menu.
+  String get homeMenuAbout;
+
+  // Semantic Label for the about button in the home page menu.
+  String get homeMenuAboutSemantics;
+
   // The long informed consent question asked of users
   String get consentStepQuestion;
 

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -9,6 +9,15 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get homeMenuTooltip => 'More';
+
+  @override
+  String get homeMenuAbout => 'About CovidNearMe';
+
+  @override
+  String get homeMenuAboutSemantics => 'About Covid Near Me';
+
+  @override
   String get consentStepQuestion => '''# Informed Consent
 
 Since the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -18,6 +18,18 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeMenuAboutSemantics => 'About Covid Near Me';
 
   @override
+  String get aboutBoxDescription =>
+      '''This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.
+
+''';
+
+  @override
+  String get aboutBoxLinkText => 'Coronavirus Diary on GitHub';
+
+  @override
+  String get aboutBoxCopyright => 'Copyright © 2020 Josh Smith';
+
+  @override
   String get consentStepQuestion => '''# Informed Consent
 
 Since the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -27,9 +27,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get aboutBoxLinkText => 'Coronavirus Diary on GitHub';
 
   @override
-  String get aboutBoxCopyright => 'Copyright © 2020 Josh Smith';
-
-  @override
   String get consentStepQuestion => '''# Informed Consent
 
 Since the US has been short on test kits, we are trying to figure out how many people have symptoms that could be due to COVID-19. The information gathered from this app will help predict where hospitals will be under the most strain. Hopefully, doctors and supplies can then be sent to the right places.

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -1,16 +1,18 @@
-import 'package:covidnearme/src/ui/screens/symptom_report/symptom_report.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'package:covidnearme/src/blocs/preferences/preferences.dart';
 import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:covidnearme/src/ui/screens/symptom_report/symptom_report.dart';
 import 'package:covidnearme/src/ui/widgets/network_unavailable_banner.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:covidnearme/src/ui/widgets/share.dart';
 import 'package:package_info/package_info.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key key}) : super(key: key);
@@ -137,12 +139,27 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 }
 
+class _LinkTextSpan extends TextSpan {
+  _LinkTextSpan({TextStyle style, String url, String text})
+      : super(
+            style: style,
+            text: text ?? url,
+            recognizer: TapGestureRecognizer()
+              ..onTap = () {
+                launch(url, forceSafariVC: false);
+              });
+}
+
 class _MainMenu extends StatelessWidget {
   static const String copyright = '© 2020 Josh Smith';
 
   @override
   Widget build(BuildContext context) {
-    final localizations = AppLocalizations.of(context);
+    final ThemeData themeData = Theme.of(context);
+    final TextStyle aboutTextStyle = themeData.textTheme.body2;
+    final TextStyle linkStyle =
+        themeData.textTheme.body2.copyWith(color: Color(0xff0000ff));
+    final AppLocalizations localizations = AppLocalizations.of(context);
     return PopupMenuButton(
       itemBuilder: (BuildContext context) {
         return <PopupMenuItem<String>>[
@@ -158,16 +175,66 @@ class _MainMenu extends StatelessWidget {
       onSelected: (String selection) async {
         assert(selection == 'About');
         PackageInfo packageInfo = await PackageInfo.fromPlatform();
-        showAboutDialog(
+        await showDialog<void>(
           context: context,
-          applicationVersion:
-              '${packageInfo.version}.${packageInfo.buildNumber}',
-          applicationLegalese: copyright,
-          applicationIcon: Image(
-            width: 50,
-            height: 50,
-            image: AssetImage('assets/images/icon.png'),
-          ),
+          useRootNavigator: true,
+          builder: (BuildContext context) {
+            return Theme(
+              data: themeData.copyWith(
+                buttonTheme: themeData.buttonTheme.copyWith(
+                  colorScheme: themeData.colorScheme,
+                ),
+              ),
+              child: AboutDialog(
+                applicationVersion:
+                    '${packageInfo.version}.${packageInfo.buildNumber}',
+                applicationLegalese: copyright,
+                applicationIcon: Image(
+                  width: 50,
+                  height: 50,
+                  image: AssetImage('assets/images/icon.png'),
+                ),
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24.0),
+                    child: RichText(
+                      text: TextSpan(
+                        children: <TextSpan>[
+                          TextSpan(
+                            style: aboutTextStyle,
+                            text:
+                                'An open source project from the Coronavirus Diary '
+                                'community. Learn more about the Coronavirus Diary '
+                                'community at ',
+                          ),
+                          _LinkTextSpan(
+                            style: linkStyle,
+                            url: 'https://covidnearme.org',
+                          ),
+                          TextSpan(
+                            style: aboutTextStyle,
+                            text:
+                                '.\n\nTo view the source code for this application, '
+                                'please visit the ',
+                          ),
+                          _LinkTextSpan(
+                            style: linkStyle,
+                            url:
+                                'https://github.com/coronavirus-diary/coronavirus-diary',
+                            text: 'coronavirus-diary github repo',
+                          ),
+                          TextSpan(
+                            style: aboutTextStyle,
+                            text: '.',
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
         );
       },
       icon: Icon(Icons.more_vert),

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -186,7 +186,6 @@ class _MainMenu extends StatelessWidget {
               child: AboutDialog(
                 applicationVersion:
                     '${packageInfo.version}.${packageInfo.buildNumber}',
-                applicationLegalese: localizations.aboutBoxCopyright,
                 applicationIcon: Image(
                   width: 50,
                   height: 50,

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -151,8 +151,6 @@ class _LinkTextSpan extends TextSpan {
 }
 
 class _MainMenu extends StatelessWidget {
-  static const String copyright = '© 2020 Josh Smith';
-
   @override
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
@@ -188,7 +186,7 @@ class _MainMenu extends StatelessWidget {
               child: AboutDialog(
                 applicationVersion:
                     '${packageInfo.version}.${packageInfo.buildNumber}',
-                applicationLegalese: copyright,
+                applicationLegalese: localizations.aboutBoxCopyright,
                 applicationIcon: Image(
                   width: 50,
                   height: 50,
@@ -202,30 +200,13 @@ class _MainMenu extends StatelessWidget {
                         children: <TextSpan>[
                           TextSpan(
                             style: aboutTextStyle,
-                            text:
-                                'An open source project from the Coronavirus Diary '
-                                'community. Learn more about the Coronavirus Diary '
-                                'community at ',
+                            text: localizations.aboutBoxDescription,
                           ),
                           _LinkTextSpan(
                             style: linkStyle,
-                            url: 'https://covidnearme.org',
-                          ),
-                          TextSpan(
-                            style: aboutTextStyle,
-                            text:
-                                '.\n\nTo view the source code for this application, '
-                                'please visit the ',
-                          ),
-                          _LinkTextSpan(
-                            style: linkStyle,
+                            text: localizations.aboutBoxLinkText,
                             url:
                                 'https://github.com/coronavirus-diary/coronavirus-diary',
-                            text: 'coronavirus-diary github repo',
-                          ),
-                          TextSpan(
-                            style: aboutTextStyle,
-                            text: '.',
                           ),
                         ],
                       ),

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -10,6 +10,7 @@ import 'package:covidnearme/src/l10n/app_localizations.dart';
 import 'package:covidnearme/src/ui/widgets/network_unavailable_banner.dart';
 import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:covidnearme/src/ui/widgets/share.dart';
+import 'package:package_info/package_info.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key key}) : super(key: key);
@@ -117,6 +118,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     icon: Icon(Icons.delete),
                     tooltip: 'DEBUG MODE ONLY: Clear user data',
                   ),
+            actions: <Widget>[_MainMenu()],
           ),
           body: NetworkUnavailableBanner.wrap(
             ScrollableBody(
@@ -131,6 +133,45 @@ class _HomeScreenState extends State<HomeScreen> {
           ),
         );
       },
+    );
+  }
+}
+
+class _MainMenu extends StatelessWidget {
+  static const String copyright = '© 2020 Josh Smith';
+
+  @override
+  Widget build(BuildContext context) {
+    final localizations = AppLocalizations.of(context);
+    return PopupMenuButton(
+      itemBuilder: (BuildContext context) {
+        return <PopupMenuItem<String>>[
+          PopupMenuItem<String>(
+            value: 'About',
+            child: Text(
+              localizations.homeMenuAbout,
+              semanticsLabel: localizations.homeMenuAboutSemantics,
+            ),
+          ),
+        ];
+      },
+      onSelected: (String selection) async {
+        assert(selection == 'About');
+        PackageInfo packageInfo = await PackageInfo.fromPlatform();
+        showAboutDialog(
+          context: context,
+          applicationVersion:
+              '${packageInfo.version}.${packageInfo.buildNumber}',
+          applicationLegalese: copyright,
+          applicationIcon: Image(
+            width: 50,
+            height: 50,
+            image: AssetImage('assets/images/icon.png'),
+          ),
+        );
+      },
+      icon: Icon(Icons.more_vert),
+      tooltip: localizations.homeMenuTooltip,
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -469,6 +469,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0+16"
   package_resolver:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -275,6 +275,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   font_awesome_flutter:
     dependency: "direct main"
     description:
@@ -349,7 +354,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.0"
   io:
     dependency: transitive
     description:
@@ -469,6 +474,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0+16"
   package_resolver:
     dependency: transitive
     description:
@@ -559,7 +571,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "1.4.2"
   pubspec_parse:
     dependency: transitive
     description:
@@ -641,7 +653,7 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.1.5"
   source_maps:
     dependency: transitive
     description:
@@ -684,13 +696,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -704,21 +709,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.2"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.2.15"
   timing:
     dependency: transitive
     description:
@@ -733,6 +738,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.4.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.6"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1+1"
   uuid:
     dependency: "direct main"
     description:
@@ -775,20 +808,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  webdriver:
-    dependency: transitive
-    description:
-      name: webdriver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.2"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0+1"
   xml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.0"
+    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -469,13 +469,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
-  package_info:
-    dependency: "direct main"
-    description:
-      name: package_info
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.0+16"
   package_resolver:
     dependency: transitive
     description:
@@ -566,7 +559,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.4"
   pubspec_parse:
     dependency: transitive
     description:
@@ -648,7 +641,7 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "2.0.0"
   source_maps:
     dependency: transitive
     description:
@@ -691,6 +684,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -704,21 +704,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.4"
+    version: "1.14.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.3"
   timing:
     dependency: transitive
     description:
@@ -775,6 +775,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0+1"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   provider: ^4.0.4
   searchable_dropdown: ^1.1.2
   share: ^0.6.3+6
+  url_launcher: ^5.4.2
   uuid: ^2.0.4
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   hydrated_bloc: ^3.0.0
   intl: ^0.16.0
   meta: ^1.1.8
+  package_info: ^0.4.0+16
   path: ^1.6.4
   path_provider: ^1.6.5
   provider: ^4.0.4


### PR DESCRIPTION
This adds an about dialog so that we can show all of the open source licenses and application information.

@joshua-s, please make sure the information I included is correct, like the copyright notice for the app, etc.

Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/172