### PR TITLE
Fix the LabeledRadio class to toggle, update pubspec.lock to latest stable hotfix.

### DIFF
--- a/lib/src/ui/widgets/questions/inputs/labeled_radio.dart
+++ b/lib/src/ui/widgets/questions/inputs/labeled_radio.dart
@@ -51,7 +51,13 @@ class LabeledRadio<T> extends StatelessWidget {
         ),
         ExcludeSemantics(
           child: GestureDetector(
-            onTap: () => onChanged(value),
+            onTap: () {
+              if (groupValue == value) {
+                onChanged(null);
+              } else {
+                onChanged(value);
+              }
+            },
             child: Text(label, style: Theme.of(context).textTheme.button),
           ),
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -349,7 +349,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.0"
   io:
     dependency: transitive
     description:
@@ -559,7 +559,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "1.4.2"
   pubspec_parse:
     dependency: transitive
     description:
@@ -641,7 +641,7 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.1.5"
   source_maps:
     dependency: transitive
     description:
@@ -684,13 +684,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.5"
-  sync_http:
-    dependency: transitive
-    description:
-      name: sync_http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -704,21 +697,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.2"
+    version: "1.9.4"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "0.2.15"
   timing:
     dependency: transitive
     description:
@@ -775,20 +768,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  webdriver:
-    dependency: transitive
-    description:
-      name: webdriver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.2"
-  webkit_inspection_protocol:
-    dependency: transitive
-    description:
-      name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.0+1"
   xml:
     dependency: transitive
     description:


### PR DESCRIPTION
I noticed that if you click the label, it doesn't toggle like it does with the Radio, so this fixes that problem.

Also, there is a new hotfix on Flutter's stable branch (1.12.13+hotfix.9), so this updates the pubspec.lock to match that.