### PR TITLE
Reset symptom report after completion.

### DIFF
--- a/lib/src/blocs/symptom_report/symptom_report_bloc.dart
+++ b/lib/src/blocs/symptom_report/symptom_report_bloc.dart
@@ -32,6 +32,9 @@ class SymptomReportBloc extends Bloc<SymptomReportEvent, SymptomReportState> {
       case CompleteSymptomReport:
         yield* _mapCompleteSymptomReportToState(event);
         break;
+      case ClearSymptomReport:
+        yield* _mapClearSymptomReportToState(event);
+        break;
     }
   }
 
@@ -76,5 +79,15 @@ class SymptomReportBloc extends Bloc<SymptomReportEvent, SymptomReportState> {
 
     // Notify app of completion
     yield const SymptomReportStateCompleted();
+  }
+
+  Stream<SymptomReportState> _mapClearSymptomReportToState(
+      ClearSymptomReport event) async* {
+    assert(
+      state is SymptomReportStateCompleted,
+      'Must be in completed state to clear symptom report, not ${state.runtimeType}.',
+    );
+
+    yield const SymptomReportStateNotCreated();
   }
 }

--- a/lib/src/blocs/symptom_report/symptom_report_event.dart
+++ b/lib/src/blocs/symptom_report/symptom_report_event.dart
@@ -27,3 +27,7 @@ class UpdateSymptomReport extends SymptomReportEvent {
 class CompleteSymptomReport extends SymptomReportEvent {
   const CompleteSymptomReport();
 }
+
+class ClearSymptomReport extends SymptomReportEvent {
+  const ClearSymptomReport();
+}

--- a/lib/src/ui/screens/symptom_report/symptom_report.dart
+++ b/lib/src/ui/screens/symptom_report/symptom_report.dart
@@ -95,9 +95,11 @@ class _SymptomReportScreenBodyState extends State<SymptomReportScreenBody> {
   }
 
   void _handleSymptomReportCompletion(
+    BuildContext context,
     SymptomReportStateCompleted symptomReportState,
   ) {
-    // TODO(goderbauer): Reset the SymptomReport bloc: https://github.com/coronavirus-diary/coronavirus-diary/issues/171
+    // Move back to the not created state, to clear out the symptom report.
+    context.bloc<SymptomReportBloc>().add(const ClearSymptomReport());
 
     // Navigate to thank you screen
     Navigator.pushReplacementNamed(
@@ -140,7 +142,7 @@ class _SymptomReportScreenBodyState extends State<SymptomReportScreenBody> {
                 });
               }
             } else if (state is SymptomReportStateCompleted) {
-              _handleSymptomReportCompletion(state);
+              _handleSymptomReportCompletion(context, state);
             }
           },
           builder: (context, state) {

--- a/lib/src/ui/screens/symptom_report/thankyou.dart
+++ b/lib/src/ui/screens/symptom_report/thankyou.dart
@@ -150,8 +150,7 @@ class _ThankYouScreenState extends State<ThankYouScreen> {
                 child: RaisedButton(
                   key: ValueKey('symptomReportThankYouFinishButton'),
                   onPressed: () => Navigator.pop(context),
-                  child: Text(
-                      localizations.thankYouScreenFinishButton),
+                  child: Text(localizations.thankYouScreenFinishButton),
                 ),
               ),
             ],

--- a/test_driver/smoke_workflow_test.dart
+++ b/test_driver/smoke_workflow_test.dart
@@ -79,6 +79,40 @@ void main() {
     await driver.waitFor(find.byValueKey('homeScreen'));
   });
 
+  test('User can enter a second report', () async {
+    // From state above, proceed to symptom report screen.
+    await driver.tap(find.byValueKey('homeScreenStartSymptomReport'));
+
+    // Intro screen is shown, continue
+    await driver.tap(find.byValueKey('symptomReportIntroStepContinueButton'));
+
+    // Enter a location and continue
+    await driver.tap(find.byValueKey('stepFinishedButton'));
+
+    // Answer the questions
+    // TODO(gspencergoog): The individual questions will need value keys or
+    // other labels so the driver test can confirm that values update correctly.
+
+    // Continue.
+    await driver.scrollUntilVisible(
+      find.byValueKey('ScrollableBody'),
+      find.byValueKey('stepFinishedButton'),
+      dyScroll: -100,
+    );
+    await driver.tap(find.byValueKey('stepFinishedButton'));
+
+    // Ensure that thank you page is shown.
+    await driver.waitFor(find.byValueKey('symptomReportThankYouScreen'));
+
+    await driver.scrollUntilVisible(
+      find.byValueKey('ScrollableBody'),
+      find.byValueKey('symptomReportThankYouFinishButton'),
+      dyScroll: -100,
+    );
+    await driver.tap(find.byValueKey('symptomReportThankYouFinishButton'));
+    await driver.waitFor(find.byValueKey('homeScreen'));
+  });
+
   test('User can tap on delete data and go back to the tutorial', () async {
     // Click on the delete data button.
     await driver.tap(find.byValueKey('homeDebugDeleteDataButton'));


### PR DESCRIPTION
Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/171 by adding a new event (`ClearSymptomReport`) triggered when transitioning back to the home screen after completing a report.

Also added driver test to make sure that the user can complete a second report after submitting the first.