### PR TITLE
[BUG] Fix app bar title on "How and when to check temperature" screen

### DIFF
--- a/lib/src/ui/widgets/questions/inputs/temperature_field.dart
+++ b/lib/src/ui/widgets/questions/inputs/temperature_field.dart
@@ -108,11 +108,17 @@ class _TemperatureFieldState extends State<TemperatureField> {
         final ThemeData theme = Theme.of(context);
         return Scaffold(
           appBar: AppBar(
-            title: Text(
-              localizations.temperatureDialogTitle,
-              style: theme.textTheme.headline
-                  .copyWith(color: theme.colorScheme.onBackground),
-              textAlign: TextAlign.center,
+            bottom: PreferredSize(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(64.0, 0.0, 16.0, 16.0),
+                child: Text(
+                  localizations.temperatureDialogTitle,
+                  style: theme.textTheme.title
+                      .copyWith(color: theme.colorScheme.onBackground),
+                  maxLines: 2,
+                ),
+              ),
+              preferredSize: Size(0.0, 80.0),
             ),
           ),
           body: ScrollMoreIndicator(


### PR DESCRIPTION
## Description

This fixes the truncation of the English version of the app bar title of the temperature screen. I also modified the text style of the title to match the screens before it, since it seemed a little off.

This change follows the Material design guidelines for handling two-line app bar titles: https://material.io/components/app-bars-top/#anatomy

## Issues

Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/200.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/27032613/79144341-a881a080-7d73-11ea-8414-9419142cfab3.png)

After: 
![Screenshot_1586799798](https://user-images.githubusercontent.com/27032613/79144318-a0296580-7d73-11ea-9d0a-e7bfd4290f7a.png)
