### PR TITLE
Add missing Korean localization for country listing

### DIFF
--- a/lib/src/l10n/country_localizations.dart
+++ b/lib/src/l10n/country_localizations.dart
@@ -36,8 +36,14 @@ class _CountryLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en', 'es', 'ru', 'vi', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+        'en',
+        'es',
+        'ko',
+        'ru',
+        'vi',
+        'zh',
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_CountryLocalizationsDelegate old) => false;
@@ -47,14 +53,15 @@ CountryLocalizations _lookupCountryLocalizations(Locale locale) {
   switch (locale.languageCode) {
     case 'es':
       return const CountryLocalizationsEs();
+    case 'ko':
+      return const CountryLocalizationsKo();
     case 'ru':
       return const CountryLocalizationsRu();
     case 'vi':
       return const CountryLocalizationsVi();
-    case 'ko':
-      return const CountryLocalizationsKo();
     case 'zh':
       return const CountryLocalizationsZh();
+    case 'en':
     default:
       return const CountryLocalizationsEn();
   }


### PR DESCRIPTION
I was trying the app out with the language set to Korean, and found out that we missed that one in the list of supported locales for the country listing. This adds it in, and alphabetizes the listing so it's easier to compare.