### PR TITLE
Add scrollable body to safety tips screen

### DIFF
--- a/lib/src/ui/screens/misc/safety_tips.dart
+++ b/lib/src/ui/screens/misc/safety_tips.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
 import 'package:covidnearme/src/l10n/app_localizations.dart';
+import 'package:covidnearme/src/ui/widgets/scrollable_body.dart';
 import 'package:covidnearme/src/ui/widgets/tutorial_step.dart';
 
 class SafetyTipsScreen extends StatelessWidget {
@@ -15,65 +16,67 @@ class SafetyTipsScreen extends StatelessWidget {
       appBar: AppBar(
         title: Text(localizations.safetyTipsTitle),
       ),
-      body: Container(
-        color: Colors.white.withOpacity(0.2),
-        padding: EdgeInsets.all(40),
-        child: Column(
-          children: <Widget>[
-            Container(
-              margin: EdgeInsets.only(bottom: 10),
-              child: Text(
-                localizations.safetyTipsTitle,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.title,
-              ),
-            ),
-            Container(
-              margin: EdgeInsets.only(bottom: 40),
-              child: Text(
-                localizations.safetyTipsSubtitle,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.subtitle,
-              ),
-            ),
-            Container(
-              margin: EdgeInsets.only(bottom: 15),
-              child: TutorialStep(
-                text: localizations.safetyTipsWashYourHands,
-                contentPadding: EdgeInsets.all(0),
-                leadingBackgroundColor: Theme.of(context).primaryColor,
-                icon: SvgPicture.asset(
-                  'assets/images/icons/handwash.svg',
-                  color: Theme.of(context).primaryIconTheme.color,
-                  width: 40,
+      body: ScrollableBody(
+        child: Container(
+          color: Colors.white.withOpacity(0.2),
+          padding: EdgeInsets.all(40),
+          child: Column(
+            children: <Widget>[
+              Container(
+                margin: EdgeInsets.only(bottom: 10),
+                child: Text(
+                  localizations.safetyTipsTitle,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.title,
                 ),
               ),
-            ),
-            Container(
-              margin: EdgeInsets.only(bottom: 15),
-              child: TutorialStep(
-                text: localizations.safetyTipsSocialDistancing,
-                contentPadding: EdgeInsets.all(0),
-                leadingBackgroundColor: Theme.of(context).primaryColor,
-                icon: SvgPicture.asset(
-                  'assets/images/icons/socialdistance.svg',
-                  color: Theme.of(context).primaryIconTheme.color,
-                  width: 40,
+              Container(
+                margin: EdgeInsets.only(bottom: 40),
+                child: Text(
+                  localizations.safetyTipsSubtitle,
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.subtitle,
                 ),
               ),
-            ),
-            Container(
-              child: TutorialStep(
-                text: localizations.safetyTipsContactPhysician,
-                leadingBackgroundColor: Theme.of(context).primaryColor,
-                icon: SvgPicture.asset(
-                  'assets/images/icons/contactprovider.svg',
-                  color: Theme.of(context).primaryIconTheme.color,
-                  width: 40,
+              Container(
+                margin: EdgeInsets.only(bottom: 15),
+                child: TutorialStep(
+                  text: localizations.safetyTipsWashYourHands,
+                  contentPadding: EdgeInsets.all(0),
+                  leadingBackgroundColor: Theme.of(context).primaryColor,
+                  icon: SvgPicture.asset(
+                    'assets/images/icons/handwash.svg',
+                    color: Theme.of(context).primaryIconTheme.color,
+                    width: 40,
+                  ),
                 ),
               ),
-            ),
-          ],
+              Container(
+                margin: EdgeInsets.only(bottom: 15),
+                child: TutorialStep(
+                  text: localizations.safetyTipsSocialDistancing,
+                  contentPadding: EdgeInsets.all(0),
+                  leadingBackgroundColor: Theme.of(context).primaryColor,
+                  icon: SvgPicture.asset(
+                    'assets/images/icons/socialdistance.svg',
+                    color: Theme.of(context).primaryIconTheme.color,
+                    width: 40,
+                  ),
+                ),
+              ),
+              Container(
+                child: TutorialStep(
+                  text: localizations.safetyTipsContactPhysician,
+                  leadingBackgroundColor: Theme.of(context).primaryColor,
+                  icon: SvgPicture.asset(
+                    'assets/images/icons/contactprovider.svg',
+                    color: Theme.of(context).primaryIconTheme.color,
+                    width: 40,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Description
On smaller devices, the safety tips screen overflows. This wraps the instructions in a ScrollableBody to allow the rest of the content to be visible.

cc/ @HansMuller 

## Issues

Fixes https://github.com/coronavirus-diary/coronavirus-diary/issues/210

![scrollable_safety_tips_screen](https://user-images.githubusercontent.com/27032613/79514981-47b8c900-7ffc-11ea-9f86-a03e0c91455e.gif)
