### PR TITLE
Update iOS Info.plist, enabling localizations on iOS devices

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>es</string>
+		<string>es_419</string>
+		<string>ko</string>
+		<string>ru</string>
+		<string>zh</string>
+		<string>zh_CN</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -9,6 +9,7 @@
 		<string>es_419</string>
 		<string>ko</string>
 		<string>ru</string>
+		<string>vi</string>
 		<string>zh</string>
 		<string>zh_CN</string>
 	</array>


### PR DESCRIPTION
Without this array of locales in `ios/Runner/Info.plist`, localizations will not work on iOS builds. I caught this by manually testing every locale on iOS for layout problems.

cc/ @HansMuller 