### PR TITLE
Fix newlines not appearing in other locales other than English for AboutDialog description

### DIFF
--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -61,7 +61,7 @@
     "description": "Semantic Label for the about button in the home page menu."
   },
 
-  "aboutBoxDescription": "This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.\n\n",
+  "aboutBoxDescription": "This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.",
   "@aboutBoxDescription":  {
     "description": "Description in the 'About' box, above a hyperlink to the source website."
   },

--- a/lib/src/l10n/app_localizations_en.dart
+++ b/lib/src/l10n/app_localizations_en.dart
@@ -50,9 +50,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get aboutBoxDescription =>
-      '''This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.
-
-''';
+      'This app is developed as an open source project by the Coronavirus Diary community. To learn more and view the source code, please visit the link below.';
 
   @override
   String get aboutBoxLinkText => 'Coronavirus Diary on GitHub';

--- a/lib/src/ui/screens/home/home.dart
+++ b/lib/src/ui/screens/home/home.dart
@@ -159,7 +159,7 @@ class _MainMenu extends StatelessWidget {
                     children: <TextSpan>[
                       TextSpan(
                         style: aboutTextStyle,
-                        text: localizations.aboutBoxDescription,
+                        text: '${localizations.aboutBoxDescription}\n\n',
                       ),
                       _LinkTextSpan(
                         style: linkStyle,


### PR DESCRIPTION
Because the translation console does not register newlines at the end of a string message, this modification needed to be made in order for the newlines to be properly displayed in locales other than English.

![005_About_Covid_Near_Me_English](https://user-images.githubusercontent.com/27032613/80519604-182f8800-893d-11ea-9bc9-70e44226469f.jpg)

![005_About_Covid_Near_Me_es-419](https://user-images.githubusercontent.com/27032613/80519607-18c81e80-893d-11ea-8e36-854e96bbc910.png)
